### PR TITLE
enable https support in elbe for apt repositories

### DIFF
--- a/ebcl/tools/root/root.xml
+++ b/ebcl/tools/root/root.xml
@@ -36,6 +36,7 @@
 		<console>{{ console }}</console>
 		<debootstrap>
 			<variant>minbase</variant>
+			<include>ca-certificates</include>
 		</debootstrap>
 		<package>
 			<tar>


### PR DESCRIPTION
Add ca-certificates to debootstrap environment.
This is necessary to allow usage of HTTPS protected apt repositories.