### PR TITLE
EBLINUX-26196: Add support for packages to initrd-generator

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -10,7 +10,6 @@
         "--disable=W0718"
     ],
     "python.testing.pytestArgs": [
-        "--no-cov",
         "--capture=no",
         "--log-level=DEBUG",
         "tests"

--- a/ebcl/tools/initrd/initrd.py
+++ b/ebcl/tools/initrd/initrd.py
@@ -254,7 +254,7 @@ class InitrdGenerator:
             mods_dir = tempfile.mkdtemp()
             logging.info('Using modules from kernel deb packages...')
             (_debs, _contents, missing) = self.config.proxy.download_deb_packages(
-                packages=self.config.kernel,
+                packages=[self.config.kernel],
                 contents=mods_dir
             )
             if missing:

--- a/ebcl/tools/initrd/initrd.py
+++ b/ebcl/tools/initrd/initrd.py
@@ -215,7 +215,8 @@ class InitrdGenerator:
         """ Download all needed deb packages. """
         (_debs, _contents, missing) = self.proxy.download_deb_packages(
             packages=self.config.packages,
-            contents=self.target_dir
+            contents=self.target_dir,
+            download_depends=True
         )
 
         if missing:

--- a/ebcl/tools/initrd/initrd.py
+++ b/ebcl/tools/initrd/initrd.py
@@ -213,8 +213,12 @@ class InitrdGenerator:
 
     def download_deb_packages(self):
         """ Download all needed deb packages. """
+        packages = self.config.packages.copy()
+        if self.config.kernel:
+            packages.remove(self.config.kernel)
+
         (_debs, _contents, missing) = self.proxy.download_deb_packages(
-            packages=self.config.packages,
+            packages=packages,
             contents=self.target_dir,
             download_depends=True
         )

--- a/ebcl/tools/initrd/initrd.py
+++ b/ebcl/tools/initrd/initrd.py
@@ -39,9 +39,6 @@ class InitrdGenerator:
             self.config.busybox = parse_package(
                 'busybox-static', self.config.arch)
 
-        if self.config.kernel:
-            self.config.packages.append(self.config.kernel)
-
         self.proxy = self.config.proxy
 
     def install_busybox(self) -> bool:
@@ -213,12 +210,8 @@ class InitrdGenerator:
 
     def download_deb_packages(self):
         """ Download all needed deb packages. """
-        packages = self.config.packages.copy()
-        if self.config.kernel:
-            packages.remove(self.config.kernel)
-
         (_debs, _contents, missing) = self.proxy.download_deb_packages(
-            packages=packages,
+            packages=self.config.packages,
             contents=self.target_dir,
             download_depends=True
         )
@@ -257,11 +250,11 @@ class InitrdGenerator:
         if self.config.modules_folder:
             mods_dir = self.config.modules_folder
             logging.info('Using modules from folder %s...', mods_dir)
-        elif self.config.packages:
+        elif self.config.kernel:
             mods_dir = tempfile.mkdtemp()
-            logging.info('Using modules from deb packages...')
+            logging.info('Using modules from kernel deb packages...')
             (_debs, _contents, missing) = self.config.proxy.download_deb_packages(
-                packages=self.config.packages,
+                packages=self.config.kernel,
                 contents=mods_dir
             )
             if missing:

--- a/tests/data/initrd.yaml
+++ b/tests/data/initrd.yaml
@@ -10,8 +10,7 @@ apt_repos:
       - nxp_public
 modules:
   - kernel/pfeng/pfeng.ko
-packages:
-  - linux-modules-5.15.0-1023-s32-eb
+kernel: linux-modules-5.15.0-1023-s32-eb
 arch: 'arm64'
 root_device: /dev/mmcblk0p2
 devices:

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -65,8 +65,8 @@ class TestConfig:
         assert len(config.modules) == 1
         assert config.modules[0] == 'kernel/pfeng/pfeng.ko'
 
-        assert len(config.packages) == 1
-        assert config.packages[0].name == 'linux-modules-5.15.0-1023-s32-eb'
+        assert len(config.packages) == 0
+        assert config.kernel is not None and config.kernel.name == 'linux-modules-5.15.0-1023-s32-eb'
 
         assert config.arch == CpuArch.ARM64
 

--- a/tests/test_initrd.py
+++ b/tests/test_initrd.py
@@ -53,6 +53,23 @@ class TestInitrd:
             self.generator.target_dir, 'bin', 'sh'))
 
     @pytest.mark.requires_download
+    def test_add_cryptsetup(self):
+        """ Test yaml config loading. """
+        vd = VersionDepends(
+            name='cryptsetup-bin',
+            package_relation=None,
+            version_relation=None,
+            version=None,
+            arch=self.generator.config.arch
+        )
+        self.generator.config.packages.append(vd)
+
+        self.generator.download_deb_packages()
+
+        assert os.path.isfile(os.path.join(
+            self.generator.target_dir, 'sbin', 'cryptsetup'))
+
+    @pytest.mark.requires_download
     def test_download_deb_package(self):
         """ Test modules package download. """
         vd = VersionDepends(


### PR DESCRIPTION
The initrd-generator shall allow downloading and extracting packages, including dependencies.
This is necessary to provide an easy way to add additional tools to the initrd.img, without requiring a full debootstrap environment as a base.

The user is responsible to ensure that the tools work as expected. The tooling only ensures to download the given packages, including dependencies, and extracts them, but doesn't run any install scripts.