### PR TITLE
EBLINUX-26937 use default gpg key for local type repo

### DIFF
--- a/ebcl/common/apt.py
+++ b/ebcl/common/apt.py
@@ -430,6 +430,12 @@ class Apt:
             logging.info('Using default Ubuntu key %s for %s.',
                          self.key_gpg, self._repo.url)
 
+        if not key_gpg and 'local' in self._repo.dist:
+            local_gpg = '/etc/apt/trusted.gpg.d/local.gpg'
+            if os.path.exists(local_gpg):
+                self.key_gpg = local_gpg
+                logging.info('Using generated gpg: %s', local_gpg)
+
     def __eq__(self, value: object) -> bool:
         if not isinstance(value, Apt):
             return False


### PR DESCRIPTION
<!-- How-to use:
Please remove this instruction and the section comments below before opening the PR.
-->

# Changes
<!-- mandatory section:
Provide a brief description of the changes in this pull request.
You can also take the description from git comments.
Please use the content of this section in the PR merge comment.
-->
When using local repo to add package to an image, it's required to provide gpg key in the yaml file. We want ebcl tooling to use locally generated gpg key implicitly, so there is no need to manually specify the key in the yaml config.

# Dependencies:
_(Provide list of pull requests with dependecies with this pull request)_

# Tests results
```bash
<!-- add Robot test CLI logs here. -->
```
# Developer Checklist:
- [ ] Test: Changes are tested
- [ ] Doc: Documentation has been updated 
- [ ] Git: Informative git commit message(s)
- [ ] Issue: If a related GitHub issue exists, linking is done

## Checklists for documentation
- [ ] Grammar: the content is grammatically correct
      (spelling, grammar, formatting, US English is used)
- [ ] Comprehensibility/Unambiguousness: the content is easy readable, clear to understand
- [ ] Correctness and consistency: the content is technically correct and consistent,
      no contradictions, no double descriptions
- [ ] Terminology: technical terms are clear and they are used correctly and documented in the glossary
- [ ] Level of detail: the content matches the detail level necessary for the reviewed object

# Reviewer checklist:
- [ ] Review: Changes are reviewed
- [ ] Review: Tested by the reviewer

## Checklists for documentation
- [ ] Grammar: the content is grammatically correct
      (spelling, grammar, formatting, US English is used)
- [ ] Comprehensibility/Unambiguousness: the content is easy readable, clear to understand
- [ ] Correctness and consistency: the content is technically correct and consistent,
      no contradictions, no double descriptions
- [ ] Terminology: technical terms are clear and they are used correctly and documented in the glossary
- [ ] Level of detail: the content matches the detail level necessary for the reviewed object
0 commit comments
Comments
0
