### PR TITLE
Allow no irqs for device in io.cfg.j2 template

### DIFF
--- a/ebcl/tools/hypervisor/data/io.cfg.j2
+++ b/ebcl/tools/hypervisor/data/io.cfg.j2
@@ -13,9 +13,11 @@ Io.Dt.add_children(hw, function()
 {%for mmio in dev.mmios %}
         Resource.reg{{loop.index0}} = Res.mmio({{"0x%x"|format(mmio.address)}}, {{"0x%x"|format(mmio.address + mmio.size - 1)}}{% if mmio.cached %}, Io.Resource.F_cached_mem | Io.Resource.F_prefetchable{% endif %})
 {% endfor %}
+{% if dev.irqs and dev.irqs|length > 0 %}
 {%for irq in dev.irqs %}
         Resource.irq{{loop.index0}} = Res.irq({{irq.irq + irq.offset}}, Io.Resource.Irq_type_{{irq.is_edge and "raising_edge" or "level_high"}})
 {% endfor %}
+{% endif %}
     end)
 {% endfor %}
 {% endfor %}


### PR DESCRIPTION
<!-- How-to use:
Please remove this instruction and the section comments below before opening the PR.
-->

# Changes
<!-- mandatory section:
Provide a brief description of the changes in this pull request.
You can also take the description from git comments.
Please use the content of this section in the PR merge comment.
-->
Included a if block, that will check, whether irqs are defined for the device and have at least one element,
before trying to write them.

Some Devices may not have interrupts defined, which is valid and should not crash the parsing.

# Dependencies:
N/A

# Tests results
```bash
<!-- add Robot test CLI logs here. -->
```
# Developer Checklist:
- [x] Test: Changes are tested
- [x] Doc: Documentation has been updated 
- [x] Git: Informative git commit message(s)
- [x] Issue: If a related GitHub issue exists, linking is done

## Checklists for documentation
- [x] Grammar: the content is grammatically correct
      (spelling, grammar, formatting, US English is used)
- [x] Comprehensibility/Unambiguousness: the content is easy readable, clear to understand
- [x] Correctness and consistency: the content is technically correct and consistent,
      no contradictions, no double descriptions
- [x] Terminology: technical terms are clear and they are used correctly and documented in the glossary
- [x] Level of detail: the content matches the detail level necessary for the reviewed object

# Reviewer checklist:
- [ ] Review: Changes are reviewed
- [ ] Review: Tested by the reviewer

## Checklists for documentation
- [x] Grammar: the content is grammatically correct
      (spelling, grammar, formatting, US English is used)
- [x] Comprehensibility/Unambiguousness: the content is easy readable, clear to understand
- [x] Correctness and consistency: the content is technically correct and consistent,
      no contradictions, no double descriptions
- [x] Terminology: technical terms are clear and they are used correctly and documented in the glossary
- [x] Level of detail: the content matches the detail level necessary for the reviewed object
0 commit comments
Comments
0
