### PR TITLE
Hypervisor tooling tests and some hardening

### DIFF
--- a/ebcl/tools/hypervisor/config_gen.py
+++ b/ebcl/tools/hypervisor/config_gen.py
@@ -35,7 +35,10 @@ class BaseResolver:
 
     def _load_file(self, filename: str) -> dict:
         with open(filename, "r", encoding="utf-8") as f:
-            return yaml.load(f, yaml.Loader)
+            data = yaml.load(f, yaml.Loader)
+            if not data:
+                data = {}
+            return data
 
 
 class HvFileGenerator:

--- a/ebcl/tools/hypervisor/data/schema.yaml
+++ b/ebcl/tools/hypervisor/data/schema.yaml
@@ -99,10 +99,12 @@ classes:
       type: MMIO
       aggregate: list
       optional: true
+      default: []
     irqs:
       type: IRQ
       aggregate: list
       optional: true
+      default: []
   MMIO:
     address:
       type: integer

--- a/ebcl/tools/hypervisor/data/schema.yaml
+++ b/ebcl/tools/hypervisor/data/schema.yaml
@@ -84,6 +84,8 @@ classes:
     devices:
       type: Device
       aggregate: list
+      optional: true
+      default: []
 
   Device:
     name:

--- a/ebcl/tools/hypervisor/data/schema.yaml
+++ b/ebcl/tools/hypervisor/data/schema.yaml
@@ -40,10 +40,6 @@ classes:
     vbus:
       type: string
       optional: true
-    vmnets:
-      type: string
-      aggregate: list
-      default: []
     shms:
       type: string
       aggregate: list

--- a/ebcl/tools/hypervisor/model.py
+++ b/ebcl/tools/hypervisor/model.py
@@ -25,7 +25,7 @@ class VNet:
         Since this is a pair, only two users are allowed
         """
         if len(self.users) == 2:
-            logging.error("VMNet %s is already used by two vms", self.name)
+            logging.error("VNet %s is already used by two vms", self.name)
         self.users.append(vm)
 
     def __repr__(self) -> str:
@@ -38,7 +38,7 @@ class VNetRef:
     """
 
     vnet: VNet
-    """Link to the vmnet"""
+    """Link to the vnet"""
     site_a: bool
     """True for one of the two sides"""
 

--- a/ebcl/tools/hypervisor/model.py
+++ b/ebcl/tools/hypervisor/model.py
@@ -106,11 +106,6 @@ class MMIO(BaseModel):
     cached: bool
     """If cached is true, the memory is mapped as normal memory instead of device memory"""
 
-#    def __init__(self, config: dict) -> None:
-#        self.address = config["address"]
-#        self.size = config["size"]
-#        self.cached = config["cached"]
-
     def __repr__(self) -> str:
         return f"MMIO(0x{self.address:x}, 0x{self.size:x})"
 
@@ -171,13 +166,6 @@ class VBus(BaseModel):
     """Name of the virtual bus used to identify it in the configuration"""
     devices: list[Device]
     """List of devices that are part of the bus"""
-
-#    def __init__(self, name: str, config: dict) -> None:
-#        self.name = name
-#
-#        self.devices = []
-#        for devname, devconfig in config.items():
-#            self.devices.append(Device(devname, devconfig))
 
     def __repr__(self) -> str:
         return f"VBus({self.name}, {', '.join(map(repr, self.devices))})"

--- a/ebcl/tools/hypervisor/model.py
+++ b/ebcl/tools/hypervisor/model.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import logging
 from typing import Literal
 
-from .model_gen import BaseModel
+from .model_gen import BaseModel, ConfigError
 
 
 class VNet:
@@ -26,7 +26,8 @@ class VNet:
         Since this is a pair, only two users are allowed
         """
         if len(self.users) == 2:
-            logging.error("VNet %s is already used by two vms", self.name)
+            names = ' and '.join(map(lambda x: x.name, self.users))
+            raise ConfigError(f"VM {vm.name}: VNet {self.name} is already used by two vms ({names})")
         self.users.append(vm)
 
     def __repr__(self) -> str:

--- a/ebcl/tools/hypervisor/model.py
+++ b/ebcl/tools/hypervisor/model.py
@@ -313,14 +313,12 @@ class HVConfig(BaseModel):
             self.vio_block.append(vio)
         if is_server:
             if vio.server:
-                logging.error("Server for Virtio Block %s already set", vio.name)
-            else:
-                vio.server = user
+                raise ConfigError(f"VM {user.name}: Server for Virtio Block {name} already set to {vio.server.name}")
+            vio.server = user
         else:
             if vio.client:
-                logging.error("Client for Virtio Block %s already set", vio.name)
-            else:
-                vio.client = user
+                raise ConfigError(f"VM {user.name}: Client for Virtio Block {name} already set to {vio.client.name}")
+            vio.client = user
         return VirtioBlockRef(vio, is_server)
 
     def get_vbus(self, name: str | None) -> VBus | None:

--- a/ebcl/tools/hypervisor/model.py
+++ b/ebcl/tools/hypervisor/model.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import logging
+from typing import Literal
 
 from .model_gen import BaseModel
 
@@ -119,9 +120,9 @@ class IRQ(BaseModel):
     """The interrupt number"""
     is_edge: bool
     """If true, the interrupt is rising edge triggered, otherwise it is level high triggered."""
-    type: str
+    type: Literal["SGI"] | Literal["PPI"] | Literal["SPI"]
     """SGI, PPI or SPI"""
-    trigger: str
+    trigger: Literal["rising_edge"] | Literal["level_high"]
     """Trigger type enum"""
 
     def __init__(self, config: dict) -> None:
@@ -134,9 +135,8 @@ class IRQ(BaseModel):
             return 0
         elif self.type == "PPI":
             return 16
-        elif self.type == "SPI":
+        else:  # "SPI"
             return 32
-        return 0
 
 
 class Device(BaseModel):

--- a/ebcl/tools/hypervisor/model.py
+++ b/ebcl/tools/hypervisor/model.py
@@ -231,10 +231,10 @@ class VM(BaseModel):
     vbus: str | VBus | None
     """The virtual bus to connect to this vm"""
     vnets: list[str] | list[VNetRef]
-    """List of virual network pairs used by this vm"""
+    """List of virtual network pairs used by this vm"""
     shms: list[str] | list[SHM]
     """List of shared memory regions available to this vm"""
-    virtio_block = list[VirtioBlockNode] | list[VirtioBlockRef]
+    virtio_block: list[VirtioBlockNode] | list[VirtioBlockRef]
 
     def finalize(self, registry: HVConfig) -> None:
         registry.register_module(self.kernel)
@@ -256,7 +256,7 @@ class VM(BaseModel):
             clients = map(
                 lambda x: registry.register_virtio_block(x, self, False), self.virtio_block.clients  # type: ignore
             )
-            self.virtio_block: list[VirtioBlockRef] = list(server) + list(clients)  # type: ignore
+            self.virtio_block = list(server) + list(clients)  # type: ignore
         else:
             self.virtio_block = []
 

--- a/tests/hypervisor/data/test_devices.yaml
+++ b/tests/hypervisor/data/test_devices.yaml
@@ -1,0 +1,22 @@
+vbus:
+  - name: empty_vbus
+  - name: a_vbus
+    devices:
+      - name: emtpy_device
+      - name: a_device
+        compatible: i am compatible
+        mmios:
+         - address: 0x123
+           size: 456
+         - address: 0x456
+           size: 789
+           cached: true
+        irqs:
+          - irq: 1
+            trigger: level_high
+          - irq: 2
+            type: PPI
+            trigger: rising_edge
+          - irq: 3
+            type: SGI
+            trigger: level_high

--- a/tests/hypervisor/data/test_missing_shms.yaml
+++ b/tests/hypervisor/data/test_missing_shms.yaml
@@ -1,0 +1,17 @@
+shms:
+  - name: shm_1
+    size: 1
+  - name: shm_2
+    size: 2
+
+vms:
+  - name: vm_1
+    kernel: kernel_1
+    dtb: dtb_1
+    ram: 10
+    cpus: 1
+    shms:
+      - shm_1
+      - shm_3
+      - shm_2
+      - shm_4

--- a/tests/hypervisor/data/test_shms.yaml
+++ b/tests/hypervisor/data/test_shms.yaml
@@ -1,0 +1,11 @@
+shms:
+  - name: shm_1
+    size: 123
+  - name: shm_2
+    size: 124
+  - name: shm_3
+    size: 0x1000
+    address: 0x2000
+  - name: shm_4
+    size: 0x1000
+    address: 0x0

--- a/tests/hypervisor/data/test_undefined_vbus.yaml
+++ b/tests/hypervisor/data/test_undefined_vbus.yaml
@@ -1,0 +1,8 @@
+
+vms:
+  - name: vm_1
+    kernel: kernel_1
+    dtb: dtb_1
+    ram: 10
+    cpus: 1
+    vbus: non_existing

--- a/tests/hypervisor/data/test_virtio_block_multiple_clients.yaml
+++ b/tests/hypervisor/data/test_virtio_block_multiple_clients.yaml
@@ -1,0 +1,17 @@
+vms:
+  - name: vm_1
+    kernel: kernel
+    dtb: dtb
+    ram: 1
+    cpus: 1
+    virtio_block:
+      clients:
+       - blk_1
+  - name: vm_2
+    kernel: kernel
+    dtb: dtb
+    ram: 1
+    cpus: 1
+    virtio_block:
+      clients:
+        - blk_1

--- a/tests/hypervisor/data/test_virtio_block_multiple_servers.yaml
+++ b/tests/hypervisor/data/test_virtio_block_multiple_servers.yaml
@@ -1,0 +1,17 @@
+vms:
+  - name: vm_1
+    kernel: kernel
+    dtb: dtb
+    ram: 1
+    cpus: 1
+    virtio_block:
+      servers:
+       - blk_1
+  - name: vm_2
+    kernel: kernel
+    dtb: dtb
+    ram: 1
+    cpus: 1
+    virtio_block:
+      servers:
+        - blk_1

--- a/tests/hypervisor/data/test_virtio_blocks.yaml
+++ b/tests/hypervisor/data/test_virtio_blocks.yaml
@@ -1,0 +1,29 @@
+vms:
+  - name: vm_1
+    kernel: kernel
+    dtb: dtb
+    ram: 1
+    cpus: 1
+    virtio_block:
+      servers:
+       - blk_1
+       - blk_2
+  - name: vm_2
+    kernel: kernel
+    dtb: dtb
+    ram: 1
+    cpus: 1
+    virtio_block:
+      servers:
+        - blk_3
+      clients:
+        - blk_1
+        - blk_2
+  - name: vm_3
+    kernel: kernel
+    dtb: dtb
+    ram: 1
+    cpus: 1
+    virtio_block:
+      clients:
+       - blk_3

--- a/tests/hypervisor/data/test_vms.yaml
+++ b/tests/hypervisor/data/test_vms.yaml
@@ -1,0 +1,27 @@
+vbus:
+  - name: a_bus
+
+shms:
+  - name: shm_1
+    size: 1
+  - name: shm_2
+    size: 2
+
+vms:
+  - name: vm_1
+    kernel: kernel_1
+    dtb: dtb_1
+    ram: 10
+    cpus: 1
+
+  - name: vm_2
+    kernel: kernel_2
+    dtb: dtb_2
+    ram: 20
+    cpus: 2
+    cmdline: a wonderful kernel cmdline
+    initrd: this is an initrd
+    vbus: a_bus
+    shms:
+      - shm_1
+      - shm_2

--- a/tests/hypervisor/data/test_vnet_too_many_users.yaml
+++ b/tests/hypervisor/data/test_vnet_too_many_users.yaml
@@ -1,0 +1,22 @@
+vms:
+  - name: vm_1
+    kernel: kernel
+    dtb: dtb
+    ram: 1
+    cpus: 1   
+    vnets:
+      - vnet_1
+  - name: vm_2
+    kernel: kernel
+    dtb: dtb
+    ram: 1
+    cpus: 1
+    vnets:
+      - vnet_1
+  - name: vm_3
+    kernel: kernel
+    dtb: dtb
+    ram: 1
+    cpus: 1
+    vnets:
+      - vnet_1

--- a/tests/hypervisor/data/test_vnets.yaml
+++ b/tests/hypervisor/data/test_vnets.yaml
@@ -1,0 +1,19 @@
+vms:
+  - name: vm_1
+    kernel: kernel
+    dtb: dtb
+    ram: 1
+    cpus: 1
+    vnets:
+      - vnet_1
+      - vnet_2
+      - vnet_3
+  - name: vm_2
+    kernel: kernel
+    dtb: dtb
+    ram: 1
+    cpus: 1
+    vnets:
+      - vnet_1
+      - vnet_3
+      - vnet_4

--- a/tests/hypervisor/test_model.py
+++ b/tests/hypervisor/test_model.py
@@ -236,3 +236,11 @@ def test_virtio_block_multiple_clients(tmp_path: Path) -> None:
         match="^" + re.escape("VM vm_2: Client for Virtio Block blk_1 already set to vm_1") + "$"
     ):
         HvFileGenerator(str(test_data / "test_virtio_block_multiple_clients.yaml"), str(tmp_path))
+
+
+def test_undefined_vbus(tmp_path: Path) -> None:
+    with pytest.raises(
+        ConfigError,
+        match="^" + re.escape("VM vm_1: VBus non_existing is not defined") + "$"
+    ):
+        HvFileGenerator(str(test_data / "test_undefined_vbus.yaml"), str(tmp_path))

--- a/tests/hypervisor/test_model.py
+++ b/tests/hypervisor/test_model.py
@@ -220,3 +220,19 @@ def test_vnet_too_many_users(tmp_path: Path) -> None:
         match="^" + re.escape("VM vm_3: VNet vnet_1 is already used by two vms (vm_1 and vm_2)") + "$"
     ):
         HvFileGenerator(str(test_data / "test_vnet_too_many_users.yaml"), str(tmp_path))
+
+
+def test_virtio_block_multiple_servers(tmp_path: Path) -> None:
+    with pytest.raises(
+        ConfigError,
+        match="^" + re.escape("VM vm_2: Server for Virtio Block blk_1 already set to vm_1") + "$"
+    ):
+        HvFileGenerator(str(test_data / "test_virtio_block_multiple_servers.yaml"), str(tmp_path))
+
+
+def test_virtio_block_multiple_clients(tmp_path: Path) -> None:
+    with pytest.raises(
+        ConfigError,
+        match="^" + re.escape("VM vm_2: Client for Virtio Block blk_1 already set to vm_1") + "$"
+    ):
+        HvFileGenerator(str(test_data / "test_virtio_block_multiple_clients.yaml"), str(tmp_path))

--- a/tests/hypervisor/test_model.py
+++ b/tests/hypervisor/test_model.py
@@ -212,3 +212,11 @@ def test_virtio_blocks(tmp_path: Path) -> None:
     assert len(vios) == 1
     assert vios[0].vio == gen.config.vio_block[2]
     assert vios[0].is_server is False
+
+
+def test_vnet_too_many_users(tmp_path: Path) -> None:
+    with pytest.raises(
+        ConfigError,
+        match="^" + re.escape("VM vm_3: VNet vnet_1 is already used by two vms (vm_1 and vm_2)") + "$"
+    ):
+        HvFileGenerator(str(test_data / "test_vnet_too_many_users.yaml"), str(tmp_path))

--- a/tests/hypervisor/test_model.py
+++ b/tests/hypervisor/test_model.py
@@ -1,0 +1,214 @@
+import re
+import pytest
+from pathlib import Path
+from typing import Any, TypeGuard
+
+from ebcl.tools.hypervisor.config_gen import HvFileGenerator
+from ebcl.tools.hypervisor.model import HVConfig, VNetRef, VirtioBlockRef
+from ebcl.tools.hypervisor.model_gen import ConfigError
+
+test_data = Path(__file__).parent / "data"
+
+
+def test_empty(tmp_path: Path) -> None:
+    gen = HvFileGenerator(str(test_data / "empty.yaml"), str(tmp_path))
+    assert gen.config
+    assert isinstance(gen.config, HVConfig)
+    assert gen.config.vbus == []
+    assert len(gen.config.modules) == 0
+
+
+def test_device(tmp_path: Path) -> None:
+    gen = HvFileGenerator(str(test_data / "test_devices.yaml"), str(tmp_path))
+    assert isinstance(gen.config, HVConfig)
+    assert len(gen.config.vbus) == 2
+
+    vbus = gen.config.get_vbus("empty_vbus")
+    assert vbus
+    assert vbus.devices == []
+
+    vbus = gen.config.get_vbus("a_vbus")
+    assert vbus
+    assert len(vbus.devices) == 2
+    assert vbus.devices[0].name == "emtpy_device"
+    assert vbus.devices[0].compatible is None
+    assert vbus.devices[0].mmios == []
+    assert vbus.devices[0].irqs == []
+
+    assert vbus.devices[1].name == "a_device"
+    assert vbus.devices[1].compatible == "i am compatible"
+    assert len(vbus.devices[1].mmios) == 2
+    vbus.devices[1].mmios[0].address == 0x123
+    vbus.devices[1].mmios[0].size == 456
+    vbus.devices[1].mmios[0].cached is False
+    vbus.devices[1].mmios[1].address == 0x456
+    vbus.devices[1].mmios[1].size == 789
+    vbus.devices[1].mmios[1].cached is True
+
+    assert len(vbus.devices[1].irqs) == 3
+    assert vbus.devices[1].irqs[0].irq == 1
+    assert vbus.devices[1].irqs[0].is_edge is False
+    assert vbus.devices[1].irqs[0].type == "SPI"
+    assert vbus.devices[1].irqs[0].offset == 32
+    assert vbus.devices[1].irqs[1].irq == 2
+    assert vbus.devices[1].irqs[1].is_edge is True
+    assert vbus.devices[1].irqs[1].type == "PPI"
+    assert vbus.devices[1].irqs[1].offset == 16
+    assert vbus.devices[1].irqs[2].irq == 3
+    assert vbus.devices[1].irqs[2].is_edge is False
+    assert vbus.devices[1].irqs[2].type == "SGI"
+    assert vbus.devices[1].irqs[2].offset == 0
+
+
+def test_shm(tmp_path: Path) -> None:
+    gen = HvFileGenerator(str(test_data / "test_shms.yaml"), str(tmp_path))
+    assert isinstance(gen.config, HVConfig)
+    assert len(gen.config.shms) == 4
+
+    gen.config.shms[0].name == "shm_1"
+    gen.config.shms[0].size == 123
+    gen.config.shms[0].address is None
+    gen.config.shms[1].name == "shm_2"
+    gen.config.shms[1].size == 124
+    gen.config.shms[1].address is None
+    gen.config.shms[2].name == "shm_3"
+    gen.config.shms[2].size == 0x1000
+    gen.config.shms[2].address == 0x2000
+    gen.config.shms[3].name == "shm_4"
+    gen.config.shms[3].size == 0x1000
+    gen.config.shms[3].address == 0x0
+
+    # Ensure sorting of shms works as expected
+    # i.e.: First shms with fixed address in address order then all others
+    sorted_shms = sorted(gen.config.shms)
+    sorted_shms[0].name == "shm_4"
+    sorted_shms[0].name == "shm_3"
+    sorted_shms[0].name == "shm_1"
+    sorted_shms[0].name == "shm_2"
+
+
+def test_vms(tmp_path: Path) -> None:
+    gen = HvFileGenerator(str(test_data / "test_vms.yaml"), str(tmp_path))
+
+    assert isinstance(gen.config, HVConfig)
+    assert len(gen.config.vms) == 2
+
+    assert set(gen.config.modules) == set([
+        "kernel_1",
+        "dtb_1",
+        "kernel_2",
+        "dtb_2",
+        "this is an initrd"
+    ])
+
+    assert gen.config.vms[0].name == "vm_1"
+    assert gen.config.vms[0].kernel == "kernel_1"
+    assert gen.config.vms[0].ram == 10
+    assert gen.config.vms[0].cpus == 1
+    assert gen.config.vms[0].cmdline == ""
+    assert gen.config.vms[0].initrd is None
+    assert gen.config.vms[0].dtb == "dtb_1"
+    assert gen.config.vms[0].vbus is None
+    assert gen.config.vms[0].shms == []
+    assert gen.config.vms[0].virtio_block == []
+    assert gen.config.vms[0].vnets == []
+
+    assert gen.config.vms[1].name == "vm_2"
+    assert gen.config.vms[1].kernel == "kernel_2"
+    assert gen.config.vms[1].ram == 20
+    assert gen.config.vms[1].cpus == 2
+    assert gen.config.vms[1].cmdline == "a wonderful kernel cmdline"
+    assert gen.config.vms[1].initrd == "this is an initrd"
+    assert gen.config.vms[1].dtb == "dtb_2"
+    assert gen.config.vms[1].vbus == gen.config.vbus[0]
+    assert gen.config.vms[1].shms == [gen.config.shms[0], gen.config.shms[1]]
+    assert gen.config.vms[1].virtio_block == []
+    assert gen.config.vms[1].vnets == []
+
+
+def test_vnets(tmp_path: Path) -> None:
+    def is_vnet_list(val: list[Any]) -> TypeGuard[list[VNetRef]]:
+        return len(val) == 0 or all(isinstance(x, VNetRef) for x in val)
+
+    gen = HvFileGenerator(str(test_data / "test_vnets.yaml"), str(tmp_path))
+
+    assert isinstance(gen.config, HVConfig)
+
+    assert len(gen.config.vms) == 2
+
+    assert len(gen.config.vnets) == 4
+    assert gen.config.vnets[0].name == "vnet_1"
+    assert gen.config.vnets[0].users == [gen.config.vms[0], gen.config.vms[1]]
+    assert gen.config.vnets[1].name == "vnet_2"
+    assert gen.config.vnets[1].users == [gen.config.vms[0]]
+    assert gen.config.vnets[2].name == "vnet_3"
+    assert gen.config.vnets[2].users == [gen.config.vms[0], gen.config.vms[1]]
+    assert gen.config.vnets[3].name == "vnet_4"
+    assert gen.config.vnets[3].users == [gen.config.vms[1]]
+
+    vnets = gen.config.vms[0].vnets
+    assert len(vnets) == 3
+    assert is_vnet_list(vnets)
+    assert vnets[0].vnet == gen.config.vnets[0]
+    assert vnets[0].name == vnets[0].vnet.name, "It is possible to access vnet properties from the ref"
+    assert vnets[0].site_a is True
+    assert vnets[1].vnet == gen.config.vnets[1]
+    assert vnets[1].site_a is True
+    assert vnets[2].vnet == gen.config.vnets[2]
+    assert vnets[2].site_a is True
+
+    vnets = gen.config.vms[1].vnets
+    assert len(vnets) == 3
+    assert is_vnet_list(vnets)
+    assert vnets[0].vnet == gen.config.vnets[0]
+    assert vnets[0].site_a is False
+    assert vnets[1].vnet == gen.config.vnets[2]
+    assert vnets[1].site_a is False
+    assert vnets[2].vnet == gen.config.vnets[3]
+    assert vnets[2].site_a is True
+
+
+def test_virtio_blocks(tmp_path: Path) -> None:
+    def is_vioref_list(val: list[Any]) -> TypeGuard[list[VirtioBlockRef]]:
+        return len(val) == 0 or all(isinstance(x, VirtioBlockRef) for x in val)
+    gen = HvFileGenerator(str(test_data / "test_virtio_blocks.yaml"), str(tmp_path))
+
+    assert isinstance(gen.config, HVConfig)
+
+    assert len(gen.config.vms) == 3
+
+    assert len(gen.config.vio_block) == 3
+    gen.config.vio_block[0].name = 'blk_1'
+    gen.config.vio_block[0].server = gen.config.vms[0]
+    gen.config.vio_block[0].client = gen.config.vms[1]
+    gen.config.vio_block[1].name = 'blk_2'
+    gen.config.vio_block[1].server = gen.config.vms[0]
+    gen.config.vio_block[1].client = gen.config.vms[1]
+    gen.config.vio_block[2].name = 'blk_3'
+    gen.config.vio_block[2].server = gen.config.vms[1]
+    gen.config.vio_block[2].client = gen.config.vms[2]
+
+    vios = gen.config.vms[0].virtio_block
+    assert is_vioref_list(vios)
+    assert len(vios) == 2
+    assert vios[0].vio == gen.config.vio_block[0]
+    assert vios[0].name == vios[0].vio.name, "It is possible to access vio directly from the ref"
+    assert vios[0].is_server is True
+    assert vios[1].vio == gen.config.vio_block[1]
+    assert vios[1].is_server is True
+
+    vios = gen.config.vms[1].virtio_block
+    assert is_vioref_list(vios)
+    assert len(vios) == 3
+    assert vios[0].vio == gen.config.vio_block[2]
+    assert vios[0].is_server is True
+    assert vios[1].vio == gen.config.vio_block[0]
+    assert vios[1].is_server is False
+    assert vios[2].vio == gen.config.vio_block[1]
+    assert vios[2].is_server is False
+
+    vios = gen.config.vms[2].virtio_block
+    assert is_vioref_list(vios)
+    assert len(vios) == 1
+    assert vios[0].vio == gen.config.vio_block[2]
+    assert vios[0].is_server is False

--- a/tests/hypervisor/test_model.py
+++ b/tests/hypervisor/test_model.py
@@ -244,3 +244,11 @@ def test_undefined_vbus(tmp_path: Path) -> None:
         match="^" + re.escape("VM vm_1: VBus non_existing is not defined") + "$"
     ):
         HvFileGenerator(str(test_data / "test_undefined_vbus.yaml"), str(tmp_path))
+
+
+def test_missing_shms(tmp_path: Path) -> None:
+    with pytest.raises(
+        ConfigError,
+        match="^" + re.escape("VM vm_1: The following shared memory segments are not defined: shm_3, shm_4") + "$"
+    ):
+        HvFileGenerator(str(test_data / "test_missing_shms.yaml"), str(tmp_path))


### PR DESCRIPTION
Adds:
 - Tests for hypervisor model
 
Changes:
  - several configuration errors changed from error logging to fatal (exception)
    - Missing shared memory segments
    - Usage of virtio net pairs for more than two VMs
    - Multiple VMs for a single virtio block server or client
    - Using a non-defined vbus in a VM
 
Fixes:
 - Correctly handle devices without mmio or irqs (default to empty list)
 - Allow vbus without devices (this was always possible but only using `devices: []` before. Not `devices` can be omitted
 - Remove commented out code