### PR TITLE
initrd_generator: implement dependencies and module lookup

### DIFF
--- a/robot_tests/data/initrd.yaml
+++ b/robot_tests/data/initrd.yaml
@@ -9,7 +9,10 @@ apt_repos:
     components:
       - nxp_public
 modules:
-  - kernel/pfeng/pfeng.ko
+  - kernel/drivers/net/virtio_net.ko # Test that old style modules still work
+  - bridge # This should also pull stp and llc
+  - stp # Test installing a module, that is also a dependency
+  - virtio # A builtin module, that shouldn't cause problems
 kernel: linux-image-generic
 arch: "arm64"
 root_device: /dev/mmcblk0p2

--- a/robot_tests/initrd.robot
+++ b/robot_tests/initrd.robot
@@ -1,11 +1,17 @@
 *** Settings ***
 Library  lib/Fakeroot.py
 Library  lib/Initrd.py
+Library  String
+Library  Collections
 Suite Setup  Setup
 Suite Teardown  Teardown
 
 *** Variables ***
 ${CONFIG}    ../data/initrd.yaml
+@{EXPECTED_MODULES}
+...    virtio_net
+...    bridge
+...    stp
 
 *** Test Cases ***
 Root Device is Mounted
@@ -37,6 +43,24 @@ File other.txt should be OK
     Should Be Owned By   /root/other.txt    123    456
     Should Have Mode     /root/other.txt    777
 
+Modules are installed
+    File Should Exist  /lib/modules/5.15.0-113-generic/modules.dep
+    
+    File Should Exist  /lib/modules/5.15.0-113-generic/kernel/drivers/net/virtio_net.ko
+    # Dependencies of virtio_net
+    File Should Exist  /lib/modules/5.15.0-113-generic/kernel/net/core/failover.ko
+    File Should Exist  /lib/modules/5.15.0-113-generic/kernel/drivers/net/net_failover.ko
+
+    File Should Exist  /lib/modules/5.15.0-113-generic/kernel/net/bridge/bridge.ko
+    # Dependencies of bridge
+    File Should Exist  /lib/modules/5.15.0-113-generic/kernel/net/802/stp.ko
+    File Should Exist  /lib/modules/5.15.0-113-generic/kernel/net/llc/llc.ko
+
+Check modules loaded by init
+    @{modules}=  Get Loaded Modules
+    Lists Should Be Equal  ${modules}  ${EXPECTED_MODULES}
+
+
 *** Keywords ***
 Setup
     Build Initrd    ${CONFIG}
@@ -44,3 +68,14 @@ Setup
 
 Teardown
     Cleanup
+
+Get Loaded Modules
+    ${init} =     Get File  /init
+    @{lines} =    Split To Lines  ${init}
+    @{matches} =  Get Matches  ${lines}  regexp=^\\s*modprobe\\s+.*$
+    @{modules}=   Create List
+    FOR  ${match}  IN  @{matches}
+        ${match} =  Replace String Using Regexp  ${match}  ^\\s*modprobe\\s+(.*)$  \\1
+        Append To List  ${modules}  ${match}
+    END
+    RETURN  @{modules}

--- a/robot_tests/lib/Fakeroot.py
+++ b/robot_tests/lib/Fakeroot.py
@@ -106,3 +106,7 @@ class Fakeroot:
         """ Check ownership of file or dir. """
         (out, _) = self.run(cmd=f'stat -c \'%a\' {path}')
         assert out.strip() == f'{mode}'
+
+    def abs_get_file(self, path: str) -> str:
+        (out, _) = self.run(cmd=f'cat {path}')
+        return out

--- a/robot_tests/lib/Initrd.py
+++ b/robot_tests/lib/Initrd.py
@@ -124,3 +124,11 @@ class Initrd:
             path=path,
             uid=int(uid),
             gid=int(gid))
+
+    def get_file(self, path: str) -> str:
+        assert self.target is not None
+        if path.startswith('/'):
+            path = path[1:]
+        path = os.path.join(self.target, path)
+
+        return self.fake.abs_get_file(path)

--- a/tests/data/initrd.yaml
+++ b/tests/data/initrd.yaml
@@ -9,7 +9,10 @@ apt_repos:
     components:
       - nxp_public
 modules:
-  - kernel/pfeng/pfeng.ko
+  - kernel/drivers/net/virtio_net.ko # Test that old style modules still work
+  - bridge # This should also pull stp and llc
+  - stp # Test installing a module, that is also a dependency
+  - virtio # A builtin module, that shouldn't cause problems
 kernel: linux-image-generic
 arch: 'arm64'
 root_device: /dev/mmcblk0p2

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -67,8 +67,7 @@ class TestConfig:
         assert isinstance(config.apt_repos[1].repo, AptDebRepo)
         assert config.apt_repos[1].repo.dist == 'ebcl_nxp_public'
 
-        assert len(config.modules) == 1
-        assert config.modules[0] == 'kernel/pfeng/pfeng.ko'
+        assert config.modules == ['kernel/drivers/net/virtio_net.ko', 'bridge', 'stp', 'virtio']
 
         assert len(config.packages) == 0
         assert config.kernel is not None and config.kernel.name == 'linux-image-generic'


### PR DESCRIPTION
# Changes
This implements automatic module dependency resolution and changes the default format for modules listed in the yaml file from path to just module name. ("kernel/net/bridge/bridge.ko" becomes "bridge").

All modules that are dependencies of the specified modules are copied to the initrd automatically and due to a correctly generated modules.dep file, they are loaded automatically as well.

This uses the hosts depmod utility (from kmod), which is not architecture agnostic so it works also for cross building.


~NOTE: This should be tested against ebcl_template before merging, I did not yet do this!~



# Tests results
```bash
==============================================================================
Robot Tests                                                                   
==============================================================================
Robot Tests.Boot                                                              
==============================================================================
Kernel exists                                                         | PASS |
------------------------------------------------------------------------------
Config is OK                                                          | PASS |
------------------------------------------------------------------------------
Script was executed                                                   | PASS |
------------------------------------------------------------------------------
Robot Tests.Boot                                                      | PASS |
3 tests, 3 passed, 0 failed
==============================================================================
Robot Tests.Initrd                                                            
==============================================================================
Root Device is Mounted                                                | PASS |
------------------------------------------------------------------------------
Devices are Created                                                   | PASS |
------------------------------------------------------------------------------
Rootfs should be set up                                               | PASS |
------------------------------------------------------------------------------
File dummy.txt should be OK                                           | PASS |
------------------------------------------------------------------------------
File other.txt should be OK                                           | PASS |
------------------------------------------------------------------------------
Modules are installed                                                 | PASS |
------------------------------------------------------------------------------
Robot Tests.Initrd                                                    | PASS |
6 tests, 6 passed, 0 failed
==============================================================================
Robot Tests.Root                                                              
==============================================================================
Systemd should exist                                                  | PASS |
------------------------------------------------------------------------------
Fakeoot config executed                                               | PASS |
------------------------------------------------------------------------------
Fakechroot config was executed                                        | PASS |
------------------------------------------------------------------------------
Chroot config was executed                                            | PASS |
------------------------------------------------------------------------------
Robot Tests.Root                                                      | PASS |
4 tests, 4 passed, 0 failed
==============================================================================
Robot Tests                                                           | PASS |
13 tests, 13 passed, 0 failed
==============================================================================
```
# Developer Checklist:
- [ ] Test: Changes are tested
- [ ] Doc: Documentation has been updated 
- [ ] Git: Informative git commit message(s)
- [ ] Issue: If a related GitHub issue exists, linking is done

## Checklists for documentation
- [ ] Grammar: the content is grammatically correct
      (spelling, grammar, formatting, US English is used)
- [ ] Comprehensibility/Unambiguousness: the content is easy readable, clear to understand
- [ ] Correctness and consistency: the content is technically correct and consistent,
      no contradictions, no double descriptions
- [ ] Terminology: technical terms are clear and they are used correctly and documented in the glossary
- [ ] Level of detail: the content matches the detail level necessary for the reviewed object

# Reviewer checklist:
- [x] Review: Changes are reviewed
- [x] Review: Tested by the reviewer

## Checklists for documentation
- [ ] Grammar: the content is grammatically correct
      (spelling, grammar, formatting, US English is used)
- [ ] Comprehensibility/Unambiguousness: the content is easy readable, clear to understand
- [ ] Correctness and consistency: the content is technically correct and consistent,
      no contradictions, no double descriptions
- [ ] Terminology: technical terms are clear and they are used correctly and documented in the glossary
- [ ] Level of detail: the content matches the detail level necessary for the reviewed object
