### PR TITLE
Adapt InitrdGenerator to handle multiple paths for busybox binary

### DIFF
--- a/ebcl/tools/initrd/initrd.py
+++ b/ebcl/tools/initrd/initrd.py
@@ -54,14 +54,21 @@ class InitrdGenerator:
         if not success:
             return False
 
-        if not os.path.isfile(os.path.join(self.target_dir, 'bin', 'busybox')):
+        busybox_paths = [
+            os.path.join(self.target_dir, 'bin', 'busybox'),
+            os.path.join(self.target_dir, 'usr', 'bin', 'busybox')
+        ]
+
+        busybox_path = next((path for path in busybox_paths if os.path.isfile(path)), None)
+
+        if not busybox_path:
             logging.critical(
                 'Busybox binary is missing! target: %s package: %s',
                 self.target_dir, package)
             return False
 
         self.config.fake.run_chroot(
-            '/bin/busybox --install -s /bin', self.target_dir)
+            f'{busybox_path} --install -s /bin', self.target_dir)
 
         return True
 


### PR DESCRIPTION
Busybox package in noble actually installs busybox to /usr/bin, while
older packages installed into /bin directly.
# Dependencies:
na

# Tests results
```bash
==============================================================================
Robot Tests                                                                   
==============================================================================
Robot Tests.Boot                                                              
==============================================================================
Kernel exists                                                         | PASS |
------------------------------------------------------------------------------
Config is OK                                                          | PASS |
------------------------------------------------------------------------------
Script was executed                                                   | PASS |
------------------------------------------------------------------------------
Robot Tests.Boot                                                      | PASS |
3 tests, 3 passed, 0 failed
==============================================================================
Robot Tests.Initrd                                                            
==============================================================================
Root Device is Mounted                                                | PASS |
------------------------------------------------------------------------------
Devices are Created                                                   | PASS |
------------------------------------------------------------------------------
Rootfs should be set up                                               | PASS |
------------------------------------------------------------------------------
File dummy.txt should be OK                                           | PASS |
------------------------------------------------------------------------------
File other.txt should be OK                                           | PASS |
------------------------------------------------------------------------------
Robot Tests.Initrd                                                    | PASS |
5 tests, 5 passed, 01 failed
==============================================================================
Robot Tests.Root                                                              
==============================================================================
Systemd should exist                                                  | PASS |
------------------------------------------------------------------------------
Fakeoot config executed                                               | PASS |
------------------------------------------------------------------------------
Fakechroot config was executed                                        | PASS |
------------------------------------------------------------------------------
Chroot config was executed                                            | PASS |
------------------------------------------------------------------------------
Robot Tests.Root                                                      | PASS |
4 tests, 4 passed, 0 failed
==============================================================================
Robot Tests                                                           | PASS |
12 tests, 12 passed, 0 failed
=============================================================================
```
# Developer Checklist:
- [x] Test: Changes are tested
- [ ] Doc: Documentation has been updated 
- [x] Git: Informative git commit message(s)
- [ ] Issue: If a related GitHub issue exists, linking is done

## Checklists for documentation
- [ ] Grammar: the content is grammatically correct
      (spelling, grammar, formatting, US English is used)
- [ ] Comprehensibility/Unambiguousness: the content is easy readable, clear to understand
- [ ] Correctness and consistency: the content is technically correct and consistent,
      no contradictions, no double descriptions
- [ ] Terminology: technical terms are clear and they are used correctly and documented in the glossary
- [ ] Level of detail: the content matches the detail level necessary for the reviewed object

# Reviewer checklist:
- [ ] Review: Changes are reviewed
- [ ] Review: Tested by the reviewer

## Checklists for documentation
- [ ] Grammar: the content is grammatically correct
      (spelling, grammar, formatting, US English is used)
- [ ] Comprehensibility/Unambiguousness: the content is easy readable, clear to understand
- [ ] Correctness and consistency: the content is technically correct and consistent,
      no contradictions, no double descriptions
- [ ] Terminology: technical terms are clear and they are used correctly and documented in the glossary
- [ ] Level of detail: the content matches the detail level necessary for the reviewed object
0 commit comments
Comments
0
