### PR TITLE
Allow apt preferences

### DIFF
--- a/tests/data/config/etc/apt/preferences.d/linux.elektrobit.com
+++ b/tests/data/config/etc/apt/preferences.d/linux.elektrobit.com
@@ -1,0 +1,3 @@
+Package: *
+Pin: origin linux.elektrobit.com
+Pin-Priority: 300

--- a/tests/data/config2/apt/preferences.d/aptconfig2
+++ b/tests/data/config2/apt/preferences.d/aptconfig2
@@ -1,0 +1,1 @@
+# Some apt config

--- a/tests/data/config3/apt/preferences.d/aptconfig3
+++ b/tests/data/config3/apt/preferences.d/aptconfig3
@@ -1,0 +1,1 @@
+# Some apt config

--- a/tests/data/config4/preferences.d/aptconfig4
+++ b/tests/data/config4/preferences.d/aptconfig4
@@ -1,0 +1,1 @@
+# Some apt config

--- a/tests/data/config5/preferences.d/aptconfig5
+++ b/tests/data/config5/preferences.d/aptconfig5
@@ -1,0 +1,1 @@
+# Some apt config

--- a/tests/data/root_debootstrap.yaml
+++ b/tests/data/root_debootstrap.yaml
@@ -1,2 +1,12 @@
 base: root.yaml
 type: debootstrap
+host_files:
+  - source: config/*
+  - source: config2/*
+    destination: etc
+  - source: config3/*
+    destination: etc/
+  - source: config4/*
+    destination: etc/apt
+  - source: config5/*
+    destination: etc/apt/


### PR DESCRIPTION
# Changes

Allow apt preferences by applying file overlays after apt config generation.
This allows overwriting the generated apt configuration and adding additional configs like apt preferences.

# Dependencies:

none

# Tests results

```bash
(.venv) (venv) ebcl@bce84abd09b2:/workspace$ pytest
======================================================================================= test session starts ========================================================================================
platform linux -- Python 3.10.12, pytest-8.3.3, pluggy-1.5.0
rootdir: /workspace
configfile: pyproject.toml
testpaths: tests
plugins: cov-6.0.0
collected 88 items                                                                                                                                                                                 

tests/hypervisor/test_model.py ...........                                                                                                                                                   [ 12%]
tests/test_apt.py .........                                                                                                                                                                  [ 22%]
tests/test_boot.py ..                                                                                                                                                                        [ 25%]
tests/test_cache.py ........                                                                                                                                                                 [ 34%]
tests/test_config.py .....                                                                                                                                                                   [ 39%]
tests/test_deb.py ..                                                                                                                                                                         [ 42%]
tests/test_dependency.py ..                                                                                                                                                                  [ 44%]
tests/test_fake.py ....                                                                                                                                                                      [ 48%]
tests/test_files.py ...................                                                                                                                                                      [ 70%]
tests/test_initrd.py ........                                                                                                                                                                [ 79%]
tests/test_proxy.py .......                                                                                                                                                                  [ 87%]
tests/test_root.py .ssss.                                                                                                                                                                    [ 94%]
tests/test_version.py .....                                                                                                                                                                  [100%]

============================================================================ 84 passed, 4 skipped in 139.18s (0:02:19) =============================================================================
```

```
(.venv) (venv) ebcl@bce84abd09b2:/workspace/robot_tests$ robot *.robot
==============================================================================
Boot & Initrd & Root                                                          
==============================================================================
Boot & Initrd & Root.Boot                                                     
==============================================================================
Kernel exists                                                         | PASS |
------------------------------------------------------------------------------
Config is OK                                                          | PASS |
------------------------------------------------------------------------------
Script was executed                                                   | PASS |
------------------------------------------------------------------------------
Boot & Initrd & Root.Boot                                             | PASS |
3 tests, 3 passed, 0 failed
==============================================================================
Boot & Initrd & Root.Initrd                                                   
==============================================================================
Root Device is Mounted                                                | PASS |
------------------------------------------------------------------------------
Devices are Created                                                   | PASS |
------------------------------------------------------------------------------
Rootfs should be set up                                               | PASS |
------------------------------------------------------------------------------
File dummy.txt should be OK                                           | PASS |
------------------------------------------------------------------------------
File other.txt should be OK                                           | PASS |
------------------------------------------------------------------------------
Modules are installed                                                 | PASS |
------------------------------------------------------------------------------
Check modules loaded by init                                          | PASS |
------------------------------------------------------------------------------
Boot & Initrd & Root.Initrd                                           | PASS |
7 tests, 7 passed, 0 failed
==============================================================================
Boot & Initrd & Root.Root                                                     
==============================================================================
Systemd should exist                                                  | PASS |
------------------------------------------------------------------------------
Fakeoot config executed                                               | PASS |
------------------------------------------------------------------------------
Fakechroot config was executed                                        | PASS |
------------------------------------------------------------------------------
Chroot config was executed                                            | PASS |
------------------------------------------------------------------------------
Boot & Initrd & Root.Root                                             | PASS |
4 tests, 4 passed, 0 failed
==============================================================================
Boot & Initrd & Root                                                  | PASS |
14 tests, 14 passed, 0 failed
==============================================================================
Output:  /workspace/robot_tests/output.xml
Log:     /workspace/robot_tests/log.html
Report:  /workspace/robot_tests/report.html
```

# Developer Checklist:

- [x] Test: Changes are tested
- N/A Doc: Documentation has been updated 
- [x] Git: Informative git commit message(s)
- N/A Issue: If a related GitHub issue exists, linking is done

# Reviewer checklist:
- [ ] Review: Changes are reviewed
- [ ] Review: Tested by the reviewer
