### PR TITLE
trust repo if no key is provided

### DIFF
--- a/tests/test_apt.py
+++ b/tests/test_apt.py
@@ -40,6 +40,48 @@ class TestApt:
         assert p[0].name == 'busybox-static'
         assert p[0].file_url is not None
 
+    def test_trusted_repo(self):
+        """ Test that repo is trusted. """
+        apt = AptDebRepo(
+            url='http://localhost',
+            dist='local',
+            components=['main'],
+            arch=CpuArch.AMD64
+        )
+
+        deb = apt.sources_entry(trusted=True)
+        assert 'trusted=yes' in deb
+
+        apt_flat = AptFlatRepo(
+            url='http://localhost',
+            directory='',
+            arch=CpuArch.AMD64
+        )
+
+        deb = apt_flat.sources_entry(trusted=True)
+        assert 'trusted=yes' in deb
+
+    def test_repo_arch(self):
+        """ Test that repo provides arch parameter. """
+        apt = AptDebRepo(
+            url='http://localhost',
+            dist='local',
+            components=['main'],
+            arch=CpuArch.AMD64
+        )
+
+        deb = apt.sources_entry(trusted=True)
+        assert 'arch=amd64' in deb
+
+        apt_flat = AptFlatRepo(
+            url='http://localhost',
+            directory='',
+            arch=CpuArch.ARM64
+        )
+
+        deb = apt_flat.sources_entry(trusted=True)
+        assert 'arch=arm64' in deb
+
     def test_download_busybox(self):
         """ Search busybox package in default apt repository. """
         p = self.apt.find_package('busybox-static')


### PR DESCRIPTION
# Changes

Trust apt repository if now gpg key is provided.

# Dependencies:

none

# Tests results

```bash
(.venv) (venv) ebcl@bce84abd09b2:/workspace$ pytest
===================================================================================================== test session starts ======================================================================================================
platform linux -- Python 3.10.12, pytest-8.3.3, pluggy-1.5.0
rootdir: /workspace
configfile: pyproject.toml
testpaths: tests
plugins: cov-6.0.0
collected 91 items                                                                                                                                                                                                             

tests/hypervisor/test_model.py ...........                                                                                                                                                                               [ 12%]
tests/test_apt.py ...........                                                                                                                                                                                            [ 24%]
tests/test_boot.py ..                                                                                                                                                                                                    [ 26%]
tests/test_cache.py ........                                                                                                                                                                                             [ 35%]
tests/test_config.py .....                                                                                                                                                                                               [ 40%]
tests/test_deb.py ..                                                                                                                                                                                                     [ 42%]
tests/test_dependency.py ..                                                                                                                                                                                              [ 45%]
tests/test_fake.py ....                                                                                                                                                                                                  [ 49%]
tests/test_files.py ...................                                                                                                                                                                                  [ 70%]
tests/test_initrd.py ........                                                                                                                                                                                            [ 79%]
tests/test_proxy.py .......                                                                                                                                                                                              [ 86%]
tests/test_root.py .ssss..                                                                                                                                                                                               [ 94%]
tests/test_version.py .....                                                                                                                                                                                              [100%]

========================================================================================== 87 passed, 4 skipped in 124.16s (0:02:04) ===========================================================================================
(.venv) (venv) ebcl@bce84abd09b2:/workspace$ cd robot_tests/
(.venv) (venv) ebcl@bce84abd09b2:/workspace/robot_tests$ robot *.robot
==============================================================================
Boot & Initrd & Root                                                          
==============================================================================
Boot & Initrd & Root.Boot                                                     
==============================================================================
Kernel exists                                                         | PASS |
------------------------------------------------------------------------------
Config is OK                                                          | PASS |
------------------------------------------------------------------------------
Script was executed                                                   | PASS |
------------------------------------------------------------------------------
Boot & Initrd & Root.Boot                                             | PASS |
3 tests, 3 passed, 0 failed
==============================================================================
Boot & Initrd & Root.Initrd                                                   
==============================================================================
Root Device is Mounted                                                | PASS |
------------------------------------------------------------------------------
Devices are Created                                                   | PASS |
------------------------------------------------------------------------------
Rootfs should be set up                                               | PASS |
------------------------------------------------------------------------------
File dummy.txt should be OK                                           | PASS |
------------------------------------------------------------------------------
File other.txt should be OK                                           | PASS |
------------------------------------------------------------------------------
Modules are installed                                                 | PASS |
------------------------------------------------------------------------------
Check modules loaded by init                                          | PASS |
------------------------------------------------------------------------------
Boot & Initrd & Root.Initrd                                           | PASS |
7 tests, 7 passed, 0 failed
==============================================================================
Boot & Initrd & Root.Root                                                     
==============================================================================
Systemd should exist                                                  | PASS |
------------------------------------------------------------------------------
Fakeoot config executed                                               | PASS |
------------------------------------------------------------------------------
Fakechroot config was executed                                        | PASS |
------------------------------------------------------------------------------
Chroot config was executed                                            | PASS |
------------------------------------------------------------------------------
Boot & Initrd & Root.Root                                             | PASS |
4 tests, 4 passed, 0 failed
==============================================================================
Boot & Initrd & Root                                                  | PASS |
14 tests, 14 passed, 0 failed
==============================================================================
Output:  /workspace/robot_tests/output.xml
Log:     /workspace/robot_tests/log.html
Report:  /workspace/robot_tests/report.html
```

# Developer Checklist:
- [x] Test: Changes are tested
- N/A Doc: Documentation has been updated 
- [x] Git: Informative git commit message(s)
- N/A Issue: If a related GitHub issue exists, linking is done

# Reviewer checklist:
- [ ] Review: Changes are reviewed
- [ ] Review: Tested by the reviewer

