### PR TITLE
fix mode for initial directories

### DIFF
--- a/ebcl/tools/initrd/initrd.py
+++ b/ebcl/tools/initrd/initrd.py
@@ -319,7 +319,7 @@ class InitrdGenerator:
         for dir_name in ['proc', 'sys', 'dev', 'sysroot', 'var', 'usr/bin',
                          'tmp', 'run', 'root', 'usr', 'usr/sbin', 'usr/lib', 'etc']:
             self.config.fake.run_sudo(
-                f'mkdir -p {os.path.join(self.target_dir, dir_name)}')
+                f'mkdir -p --mode=0755 {os.path.join(self.target_dir, dir_name)}')
 
         # Create lib and bin folder symlinks
         self.config.fake.run_sudo(f'ln -sf usr/lib {self.target_dir}/lib')


### PR DESCRIPTION
# Changes

Currently creating initial directories like /usr/bin in the change root depends on the host environment, e.g. umask settings.
This has been observed in codespaces, maybe related to ACL settings. Also the umask maybe misconfigured via vscode plugins (e.g. ssh new file mode setting). As a symptom the check for busybox paths has been failing with PermissionErrors.

This change explicitly pins the directory access modes, and not rely on the host / user settings.

Thanks @MofX for proposing the solution.

# Dependencies:

n/a

# Tests results
```bash
<!-- add Robot test CLI logs here. -->
```
# Developer Checklist:
- [x] Test: Changes are tested
- [ ] Doc: Documentation has been updated 
- [x] Git: Informative git commit message(s)
- [ ] Issue: If a related GitHub issue exists, linking is done

# Reviewer checklist:
- [ ] Review: Changes are reviewed
- [ ] Review: Tested by the reviewer
