### PR TITLE
Output log

### DIFF
--- a/ebcl/common/__init__.py
+++ b/ebcl/common/__init__.py
@@ -1,4 +1,5 @@
 """ Common functions of the EBcL build helpers """
+from argparse import ArgumentParser
 import logging
 import os
 
@@ -12,7 +13,17 @@ class ImplementationError(Exception):
     """ Raised if a assumption is not met. """
 
 
-def init_logging(level: str = 'INFO') -> None:
+def add_loging_arguments(parser: ArgumentParser) -> None:
+    """ Add default logging parameters to an argparser """
+    parser.add_argument(
+        '--logfile',
+        metavar="FILENAME",
+        default=None,
+        help="Log into file instead of stdout"
+    )
+
+
+def init_logging(args, level: str = 'INFO') -> None:
     """ Initialize the logging for the EBcL build tools. """
     log_format = '[{asctime}] {levelname:<6s} {filename:s}:{lineno:d} - {message:s}'
     log_date_format = '%m/%d/%Y %I:%M:%S %p'
@@ -26,7 +37,8 @@ def init_logging(level: str = 'INFO') -> None:
         level=used_level,
         format=log_format,
         style='{',
-        datefmt=log_date_format
+        datefmt=log_date_format,
+        filename=args.logfile
     )
 
     logging.info('Setting log level to %s. (default: %s, env: %s)',
@@ -40,7 +52,7 @@ def bug(bug_url: str = 'https://github.com/Elektrobit/ebcl_build_tools/issues') 
     text += f"You are using EBcl build tooling version {ebcl.__version__},"
     text += f"and EB corbos Linux workspace version {os.getenv('RELEASE_VERSION', None)}"
 
-    print(text)
+    logging.error(text)
 
 
 def promo() -> None:
@@ -48,7 +60,7 @@ def promo() -> None:
     release_version = os.getenv('RELEASE_VERSION', None)
 
     if release_version:
-        print(f'Thanks for using EB corbos Linux workspace {release_version}!')
+        logging.info('Thanks for using EB corbos Linux workspace %s!', release_version)
     else:
         text = '\n'
         text += "=========================================================================\n"
@@ -58,7 +70,7 @@ def promo() -> None:
         text += "=========================================================================\n"
         text += '\n'
 
-        print(text)
+        logging.info(text)
 
 
 RT = TypeVar('RT')

--- a/ebcl/common/deb.py
+++ b/ebcl/common/deb.py
@@ -273,6 +273,7 @@ class DebFile:
             ],
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
+            stdin=subprocess.DEVNULL,
             check=False,
             encoding="utf-8"
         )

--- a/ebcl/common/files.py
+++ b/ebcl/common/files.py
@@ -52,14 +52,13 @@ class Files:
         self, cmd: str,
         env: Optional[EnvironmentType],
         cwd: Optional[str] = None,
-        check: bool = True,
-        capture_output=True
+        check: bool = True
     ) -> Optional[Tuple[Optional[str], Optional[str], int]]:
         """ Run the cmd using fake. """
         if env == EnvironmentType.FAKEROOT:
-            return self.fake.run_fake(cmd, cwd=cwd, check=check, capture_output=capture_output)
+            return self.fake.run_fake(cmd, cwd=cwd, check=check)
         elif env == EnvironmentType.SUDO:
-            return self.fake.run_sudo(cmd, cwd=cwd, check=check, capture_output=capture_output)
+            return self.fake.run_sudo(cmd, cwd=cwd, check=check)
         elif env == EnvironmentType.CHROOT:
             chroot_dir: Optional[str] = None
             if cwd:
@@ -73,9 +72,9 @@ class Files:
 
             cmd = cmd.replace(chroot_dir, '')
 
-            return self.fake.run_chroot(cmd, chroot=chroot_dir, check=check, capture_output=capture_output)
+            return self.fake.run_chroot(cmd, chroot=chroot_dir, check=check)
         elif env == EnvironmentType.SHELL or env is None:
-            return self.fake.run_cmd(cmd, cwd=cwd, check=check, capture_output=capture_output)
+            return self.fake.run_cmd(cmd, cwd=cwd, check=check)
 
     def copy_files(
         self,
@@ -262,8 +261,7 @@ class Files:
         params: Optional[str] = None,
         environment: Optional[EnvironmentType] = None,
         cwd: Optional[str] = None,
-        check: bool = True,
-        capture_output: bool = True
+        check: bool = True
     ) -> Optional[Tuple[Optional[str], Optional[str], int]]:
         """ Run scripts. """
         if not params:
@@ -307,8 +305,7 @@ class Files:
                 cmd=f'{script_file} {params}',
                 env=environment,
                 cwd=target_dir,
-                check=check,
-                capture_output=capture_output
+                check=check
             )
 
             if os.path.abspath(script_file) != os.path.abspath(file):

--- a/ebcl/tools/boot/boot.py
+++ b/ebcl/tools/boot/boot.py
@@ -8,7 +8,7 @@ import tempfile
 
 from typing import Optional
 
-from ebcl.common import init_logging, promo, log_exception
+from ebcl.common import add_loging_arguments, init_logging, promo, log_exception
 from ebcl.common.config import Config
 from ebcl.common.files import resolve_file
 
@@ -148,20 +148,21 @@ class BootGenerator:
 @log_exception(call_exit=True)
 def main() -> None:
     """ Main entrypoint of EBcL boot generator. """
-    init_logging()
-
-    logging.info('\n===================\n'
-                 'EBcL Boot Generator\n'
-                 '===================\n')
-
     parser = argparse.ArgumentParser(
-        description='Create the content of the boot partiton.')
+        description='Create the content of the boot partition.')
+    add_loging_arguments(parser)
     parser.add_argument('config_file', type=str,
                         help='Path to the YAML configuration file')
     parser.add_argument('output', type=str,
                         help='Path to the output directory')
 
     args = parser.parse_args()
+
+    init_logging(args)
+
+    logging.info('\n===================\n'
+                 'EBcL Boot Generator\n'
+                 '===================\n')
 
     logging.debug('Running boot_generator with args %s', args)
 
@@ -175,10 +176,10 @@ def main() -> None:
     generator.finalize()
 
     if image:
-        print(f'Results were written to {image}.')
+        logging.info('Results were written to %s.', image)
         promo()
     else:
-        print('Build failed!')
+        logging.error('Build failed!')
         exit(1)
 
 

--- a/ebcl/tools/downloader/downloader.py
+++ b/ebcl/tools/downloader/downloader.py
@@ -7,7 +7,7 @@ import tempfile
 
 from typing import Optional
 
-from ebcl.common import init_logging, promo, log_exception
+from ebcl.common import add_loging_arguments, init_logging, promo, log_exception
 from ebcl.common.config import Config
 from ebcl.common.version import VersionDepends
 
@@ -74,23 +74,18 @@ class PackageDownloader:
         if missing:
             logging.error('Not found packages: %s', missing)
 
-        print(f'The packages were downloaded to:\n{output_path}')
-        print(f'The packages were extracted to:\n{content_path}')
+        logging.info('The packages were downloaded to:\n%s', output_path)
+        logging.info('The packages were extracted to:\n%s', content_path)
 
 
 @log_exception(call_exit=True)
 def main() -> None:
     """ Main entrypoint of EBcL boot generator. """
-    init_logging()
-
-    logging.info('\n======================\n'
-                 'EBcL Package downloader\n'
-                 '=======================\n')
-
     parser = argparse.ArgumentParser(
         description='Download and extract the given packages.')
+    add_loging_arguments(parser)
     parser.add_argument('config', type=str,
-                        help='Path to the YAML configuration file containing the apt repostory config.')
+                        help='Path to the YAML configuration file containing the apt repository config.')
     parser.add_argument('packages', type=str,
                         help='List of packages separated by space.')
     parser.add_argument('-o', '--output', type=str,
@@ -101,6 +96,12 @@ def main() -> None:
                         help='Download all package dependencies recursive.')
 
     args = parser.parse_args()
+
+    init_logging(args)
+
+    logging.info('\n======================\n'
+                 'EBcL Package downloader\n'
+                 '=======================\n')
 
     downloader = PackageDownloader(args.config, args.output)
 

--- a/ebcl/tools/hypervisor/config_gen.py
+++ b/ebcl/tools/hypervisor/config_gen.py
@@ -8,7 +8,7 @@ from tempfile import TemporaryDirectory
 import jinja2
 import yaml
 
-from ebcl.common import init_logging, log_exception
+from ebcl.common import add_loging_arguments, init_logging, log_exception
 from ebcl.common.config import Config
 from ebcl.common.files import resolve_file
 from ebcl.common.version import VersionDepends
@@ -156,14 +156,9 @@ class SpecializationUnpacker:
 @log_exception(call_exit=True)
 def main() -> None:
     """ Main entrypoint of EBcL hypervisor generator. """
-    init_logging()
-
-    logging.info('\n===================\n'
-                 'EBcL Hypervisor Config File Generator\n'
-                 '===================\n')
-
     parser = argparse.ArgumentParser(
         description='Create the config files for the hypervisor')
+    add_loging_arguments(parser)
     parser.add_argument('-s', '--specialization', type=Path,
                         help='Path to hypervisor specialization directory')
     parser.add_argument('-p', '--specialization-package', type=str,
@@ -177,6 +172,12 @@ def main() -> None:
     parser.add_argument('output', type=Path,
                         help='Path to the output directory')
     args = parser.parse_args()
+
+    init_logging(args)
+
+    logging.info('\n===================\n'
+                 'EBcL Hypervisor Config File Generator\n'
+                 '===================\n')
 
     if args.specialization_package:
         if not args.repo_config or not args.repo_config.exists():

--- a/ebcl/tools/initrd/initrd.py
+++ b/ebcl/tools/initrd/initrd.py
@@ -13,7 +13,7 @@ import tempfile
 from pathlib import Path
 from typing import Any, Callable, Optional
 
-from ebcl.common import init_logging, promo, log_exception
+from ebcl.common import add_loging_arguments, init_logging, promo, log_exception
 from ebcl.common.config import Config, InvalidConfiguration
 from ebcl.common.files import EnvironmentType
 from ebcl.common.templates import render_template
@@ -426,20 +426,21 @@ class InitrdGenerator:
 @log_exception(call_exit=True)
 def main() -> None:
     """ Main entrypoint of EBcL initrd generator. """
-    init_logging()
-
-    logging.info('\n====================\n'
-                 'EBcL Initrd Generator\n'
-                 '=====================\n')
-
     parser = argparse.ArgumentParser(
         description='Create an initrd image for Linux.')
+    add_loging_arguments(parser)
     parser.add_argument('config_file', type=str,
                         help='Path to the YAML configuration file')
     parser.add_argument('output', type=str,
                         help='Path to the output directory')
 
     args = parser.parse_args()
+
+    init_logging(args)
+
+    logging.info('\n====================\n'
+                 'EBcL Initrd Generator\n'
+                 '=====================\n')
 
     logging.debug('Running initrd_generator with args %s', args)
 
@@ -453,10 +454,10 @@ def main() -> None:
     generator.finalize()
 
     if image:
-        print(f'Image was written to {image}.')
+        logging.info('Image was written to %s.', image)
         promo()
     else:
-        print('Image build failed!')
+        logging.error('Image build failed!')
         exit(1)
 
 

--- a/ebcl/tools/proxy/proxy.py
+++ b/ebcl/tools/proxy/proxy.py
@@ -3,23 +3,24 @@
 import argparse
 import logging
 
-from ebcl.common import init_logging
+from ebcl.common import add_loging_arguments, init_logging
 
 # TODO: implmement
 
 
 def main() -> None:
     """ Main entrypoint of EBcL apt proxy. """
-    init_logging()
+    parser = argparse.ArgumentParser(
+        description='EBcL apt proxy.')
+    add_loging_arguments(parser)
+
+    args = parser.parse_args()
+
+    init_logging(args)
 
     logging.info('\n=========\n'
                  'EBcL Proxy\n'
                  '==========\n')
-
-    parser = argparse.ArgumentParser(
-        description='EBcL apt proxy.')
-
-    _args = parser.parse_args()
 
     logging.critical('Not implemented!')
 

--- a/ebcl/tools/root/root.py
+++ b/ebcl/tools/root/root.py
@@ -8,7 +8,7 @@ import tempfile
 from typing import Optional
 
 from ebcl import __version__
-from ebcl.common import init_logging, promo, log_exception
+from ebcl.common import add_loging_arguments, init_logging, promo, log_exception
 from ebcl.common.config import Config
 from ebcl.common.version import parse_package_config
 from ebcl.tools.root.kiwi import build_kiwi_image
@@ -151,11 +151,11 @@ class RootGenerator:
             self.config.fake.run_fake(
                 f'cp -R {self.result_dir}/* {self.config.output_path}')
         except Exception as e:
-            logging.error('Copying all artefacts failed! %s', e)
+            logging.error('Copying all artifacts failed! %s', e)
 
         if logging.root.level == logging.DEBUG:
             logging.debug(
-                'Log level set to debug, skipping cleanup of build artefacts.')
+                'Log level set to debug, skipping cleanup of build artifacts.')
             logging.debug('Target folder: %s', self.config.target_dir)
             logging.debug('Results folder: %s', self.result_dir)
             return
@@ -171,14 +171,9 @@ class RootGenerator:
 @log_exception(call_exit=True)
 def main() -> None:
     """ Main entrypoint of EBcL root generator. """
-    init_logging()
-
-    logging.info('\n=========================\n'
-                 'EBcL Root Generator %s\n'
-                 '=========================\n', __version__)
-
     parser = argparse.ArgumentParser(
-        description='Create the content of the root partiton as root.tar.')
+        description='Create the content of the root partition as root.tar.')
+    add_loging_arguments(parser)
     parser.add_argument('config_file', type=str,
                         help='Path to the YAML configuration file')
     parser.add_argument('output', type=str,
@@ -189,6 +184,12 @@ def main() -> None:
                         help='Skip the config script execution.')
 
     args = parser.parse_args()
+
+    init_logging(args)
+
+    logging.info('\n=========================\n'
+                 'EBcL Root Generator %s\n'
+                 '=========================\n', __version__)
 
     logging.debug('Running root_generator with args %s', args)
 
@@ -204,7 +205,7 @@ def main() -> None:
     generator.finalize()
 
     if image:
-        print(f'Image was written to {image}.')
+        logging.info('Image was written to %s.', image)
         promo()
     else:
         exit(1)

--- a/ebcl/tools/root/root_config.py
+++ b/ebcl/tools/root/root_config.py
@@ -6,7 +6,7 @@ import os
 
 from typing import Optional
 
-from ebcl.common import init_logging, promo, log_exception
+from ebcl.common import add_loging_arguments, init_logging, promo, log_exception
 from ebcl.common.config import Config
 
 from . import config_root
@@ -33,20 +33,21 @@ class RootConfig:
 @log_exception(call_exit=True)
 def main() -> None:
     """ Main entrypoint of EBcL root filesystem config helper. """
-    init_logging()
-
-    logging.info('\n=====================\n'
-                 'EBcL Root Configurator\n'
-                 '======================\n')
-
     parser = argparse.ArgumentParser(
         description='Configure the given root tarball.')
+    add_loging_arguments(parser)
     parser.add_argument('config_file', type=str,
                         help='Path to the YAML configuration file')
     parser.add_argument('archive_in', type=str, help='Root tarball.')
     parser.add_argument('archive_out', type=str, help='New tarball.')
 
     args = parser.parse_args()
+
+    init_logging(args)
+
+    logging.info('\n=====================\n'
+                 'EBcL Root Configurator\n'
+                 '======================\n')
 
     logging.debug('Running root_configurator with args %s', args)
 
@@ -56,7 +57,7 @@ def main() -> None:
     archive = generator.config_root(args.archive_in, args.archive_out)
 
     if archive:
-        print(f'Archive was written to {archive}.')
+        logging.info('Archive was written to %s.', archive)
         promo()
     else:
         exit(1)

--- a/robot_tests/lib/Fakeroot.py
+++ b/robot_tests/lib/Fakeroot.py
@@ -41,7 +41,8 @@ class Fakeroot:
             check=True,
             shell=True,
             stdout=PIPE,
-            stderr=PIPE)
+            stderr=PIPE
+        )
 
         pout = ''
         perr = ''

--- a/tests/test_fake.py
+++ b/tests/test_fake.py
@@ -34,8 +34,7 @@ class TestFake:
 
     def test_run_cmd(self):
         """ Run a command using a default shell. """
-        (stdout, stderr, _returncode) = self.fake.run_cmd(
-            'id', capture_output=True)
+        (stdout, stderr, _returncode) = self.fake.run_cmd('id')
         assert stdout is not None
         assert f'uid={os.getuid()}' in stdout
         assert f'gid={os.getgid()}' in stdout
@@ -44,8 +43,7 @@ class TestFake:
 
     def test_run_fake(self):
         """ Run a command using fakeroot. """
-        (stdout, stderr, _returncode) = self.fake.run_fake(
-            'id', capture_output=True)
+        (stdout, stderr, _returncode) = self.fake.run_fake('id')
         assert stdout is not None
         assert 'uid=0(root)' in stdout
         assert 'gid=0(root)' in stdout
@@ -71,19 +69,19 @@ class TestFake:
 
         # Install busybox
         (_stdout, stderr, _returncode) = self.fake.run_chroot(
-            '/bin/busybox --install -s /bin', chroot, capture_output=True)
+            '/bin/busybox --install -s /bin', chroot)
         assert stderr is not None
         assert not stderr.strip()
 
         # Create resolv.conf symlink
         (_stdout, stderr, _returncode) = self.fake.run_chroot(
-            'ln -sf etc etc/resolv.conf', chroot, capture_output=True)
+            'ln -sf etc etc/resolv.conf', chroot)
         assert stderr is not None
         assert not stderr.strip()
 
         # Check proc is mounted
         (stdout, stderr, _returncode) = self.fake.run_chroot(
-            'stat -c \'%u %g\' /proc/cmdline', chroot, capture_output=True)
+            'stat -c \'%u %g\' /proc/cmdline', chroot)
         assert stdout
         assert stdout.strip() == '0 0'
         assert stderr is not None
@@ -91,7 +89,7 @@ class TestFake:
 
         # Check sysfs is mounted
         (stdout, stderr, _returncode) = self.fake.run_chroot(
-            'stat -c \'%u %g\' /sys/dev', chroot, capture_output=True)
+            'stat -c \'%u %g\' /sys/dev', chroot)
         assert stdout
         assert stdout.strip() == '0 0'
         assert stderr is not None
@@ -99,7 +97,7 @@ class TestFake:
 
         # Check dev/pts is mounted
         (stdout, stderr, _returncode) = self.fake.run_chroot(
-            'stat -c \'%u %g\' /dev/pts', chroot, capture_output=True)
+            'stat -c \'%u %g\' /dev/pts', chroot)
         assert stdout
         assert stdout.strip() == '0 0'
         assert stderr is not None
@@ -107,14 +105,14 @@ class TestFake:
 
         # Check DNS config
         (stdout, stderr, _returncode) = self.fake.run_chroot(
-            'stat -c \'%u %g\' /etc/resolv.conf', chroot, capture_output=True)
+            'stat -c \'%u %g\' /etc/resolv.conf', chroot)
         assert stdout
         assert stdout.strip() == '0 0'
         assert stderr is not None
         assert not stderr.strip()
 
         (stdout, stderr, _returncode) = self.fake.run_chroot(
-            'stat -c \'%u %g\' /etc/gai.conf', chroot, capture_output=True)
+            'stat -c \'%u %g\' /etc/gai.conf', chroot)
         assert stdout
         assert stdout.strip() == '0 0'
         assert stderr is not None
@@ -122,7 +120,7 @@ class TestFake:
 
         # Check reslov.conf symlink still exists
         (stdout, stderr, _returncode) = self.fake.run_sudo(
-            'stat -c \'%u %g\' /etc/resolv.conf', chroot, capture_output=True)
+            'stat -c \'%u %g\' /etc/resolv.conf', chroot)
         assert stdout
         assert stdout.strip() == '0 0'
         assert stderr is not None
@@ -148,12 +146,12 @@ class TestFake:
 
         # Install busybox
         (_stdout, stderr, _returncode) = self.fake.run_chroot(
-            '/bin/busybox --install -s /bin', chroot, capture_output=True)
+            '/bin/busybox --install -s /bin', chroot)
         assert stderr is not None
         assert not stderr.strip()
 
         (stdout, stderr, returncode) = self.fake.run_chroot(
-            'ping -c 1 linux.elektrobit.com', chroot, capture_output=True)
+            'ping -c 1 linux.elektrobit.com', chroot)
         assert returncode == 0
         assert stderr is not None
         assert not stderr.strip()
@@ -177,7 +175,7 @@ class TestFake:
 
         # Install busybox
         (_stdout, stderr, _returncode) = self.fake.run_chroot(
-            '/bin/busybox --install -s /bin', chroot, capture_output=True)
+            '/bin/busybox --install -s /bin', chroot)
         assert stderr is not None
         assert not stderr.strip()
 
@@ -186,7 +184,7 @@ class TestFake:
     def test_run_sudo(self):
         """ Run a command using sudo. """
         (stdout, stderr, _returncode) = self.fake.run_sudo(
-            'id', capture_output=True)
+            'id')
         assert stdout is not None
         assert 'uid=0(root)' in stdout
         assert 'gid=0(root)' in stdout

--- a/tests/test_files.py
+++ b/tests/test_files.py
@@ -90,7 +90,7 @@ class TestFiles:
         assert files
 
         (out, err, ret) = self.fake.run_sudo(
-            f'file {self.target_dir}/cp_root_shell', capture_output=True)
+            f'file {self.target_dir}/cp_root_shell')
         assert ret == 0
         assert err is not None
         assert not err.strip()
@@ -98,13 +98,13 @@ class TestFiles:
         assert 'ASCII text' in out
 
         (out, err, ret) = self.fake.run_sudo(
-            f'stat -c \'%u %g %a\'  {self.target_dir}/cp_root_shell', capture_output=True)
+            f'stat -c \'%u %g %a\'  {self.target_dir}/cp_root_shell')
         assert ret == 0
         assert err is not None
         assert not err.strip()
         assert out
         (mode, _err, _ret) = self.fake.run_sudo(
-            f'stat -c \'%a\'  {self.other_dir}/root', capture_output=True)
+            f'stat -c \'%a\'  {self.other_dir}/root')
         assert mode
         mode = mode.strip()
         assert f'{os.getuid()} {os.getgid()} {mode}' in out.strip()
@@ -117,7 +117,7 @@ class TestFiles:
         assert files
 
         (out, err, ret) = self.fake.run_cmd(
-            f'file {self.target_dir}/cp_user_shell', capture_output=True)
+            f'file {self.target_dir}/cp_user_shell')
         assert ret == 0
         assert err is not None
         assert not err.strip()
@@ -125,13 +125,13 @@ class TestFiles:
         assert 'ASCII text' in out
 
         (out, err, ret) = self.fake.run_cmd(
-            f'stat -c \'%u %g %a\'  {self.target_dir}/cp_user_shell', capture_output=True)
+            f'stat -c \'%u %g %a\'  {self.target_dir}/cp_user_shell')
         assert ret == 0
         assert err is not None
         assert not err.strip()
         assert out
         (mode, _err, _ret) = self.fake.run_cmd(
-            f'stat -c \'%a\'  {self.other_dir}/user', capture_output=True)
+            f'stat -c \'%a\'  {self.other_dir}/user')
         assert mode
         mode = mode.strip()
         assert f'{os.getuid()} {os.getgid()} {mode}' in out.strip()
@@ -146,7 +146,7 @@ class TestFiles:
         assert files
 
         (out, err, ret) = self.fake.run_cmd(
-            f'file {self.target_dir}/cp_root_sudo', capture_output=True)
+            f'file {self.target_dir}/cp_root_sudo')
         assert ret == 0
         assert err is not None
         assert not err.strip()
@@ -154,13 +154,13 @@ class TestFiles:
         assert 'ASCII text' in out
 
         (out, err, ret) = self.fake.run_cmd(
-            f'stat -c \'%u %g %a\'  {self.target_dir}/cp_root_sudo', capture_output=True)
+            f'stat -c \'%u %g %a\'  {self.target_dir}/cp_root_sudo')
         assert ret == 0
         assert err is not None
         assert not err.strip()
         assert out
         (mode, _err, _ret) = self.fake.run_cmd(
-            f'stat -c \'%a\'  {self.other_dir}/root', capture_output=True)
+            f'stat -c \'%a\'  {self.other_dir}/root')
         assert mode
         mode = mode.strip()
         assert f'0 0 {mode}' in out.strip()
@@ -173,7 +173,7 @@ class TestFiles:
         assert files
 
         (out, err, ret) = self.fake.run_cmd(
-            f'file {self.target_dir}/cp_user_sudo', capture_output=True)
+            f'file {self.target_dir}/cp_user_sudo')
         assert ret == 0
         assert err is not None
         assert not err.strip()
@@ -181,7 +181,7 @@ class TestFiles:
         assert 'ASCII text' in out
 
         (out, err, ret) = self.fake.run_cmd(
-            f'stat -c \'%u %g %a\'  {self.target_dir}/cp_user_sudo', capture_output=True)
+            f'stat -c \'%u %g %a\'  {self.target_dir}/cp_user_sudo')
         assert ret == 0
         assert err is not None
         assert not err.strip()
@@ -198,7 +198,7 @@ class TestFiles:
         assert files
 
         (out, err, ret) = self.fake.run_fake(
-            f'file {self.target_dir}/cp_root_fake', capture_output=True)
+            f'file {self.target_dir}/cp_root_fake')
         assert ret == 0
         assert err is not None
         assert not err.strip()
@@ -206,13 +206,13 @@ class TestFiles:
         assert 'ASCII text' in out
 
         (out, err, ret) = self.fake.run_fake(
-            f'stat -c \'%u %g %a\'  {self.target_dir}/cp_root_fake', capture_output=True)
+            f'stat -c \'%u %g %a\'  {self.target_dir}/cp_root_fake')
         assert ret == 0
         assert err is not None
         assert not err.strip()
         assert out
         (mode, _err, _ret) = self.fake.run_fake(
-            f'stat -c \'%a\'  {self.other_dir}/root', capture_output=True)
+            f'stat -c \'%a\'  {self.other_dir}/root')
         assert mode
         mode = mode.strip()
         assert f'0 0 {mode}' in out.strip()
@@ -225,7 +225,7 @@ class TestFiles:
         assert files
 
         (out, err, ret) = self.fake.run_fake(
-            f'file {self.target_dir}/cp_user_fake', capture_output=True)
+            f'file {self.target_dir}/cp_user_fake')
         assert ret == 0
         assert err is not None
         assert not err.strip()
@@ -233,13 +233,13 @@ class TestFiles:
         assert 'ASCII text' in out
 
         (out, err, ret) = self.fake.run_fake(
-            f'stat -c \'%u %g %a\'  {self.target_dir}/cp_user_fake', capture_output=True)
+            f'stat -c \'%u %g %a\'  {self.target_dir}/cp_user_fake')
         assert ret == 0
         assert err is not None
         assert not err.strip()
         assert out
         (mode, _err, _ret) = self.fake.run_fake(
-            f'stat -c \'%a\'  {self.other_dir}/user', capture_output=True)
+            f'stat -c \'%a\'  {self.other_dir}/user')
         assert mode
         mode = mode.strip()
         assert f'0 0 {mode}' in out.strip()
@@ -261,7 +261,7 @@ class TestFiles:
 
         # Install busybox
         (_stdout, stderr, _returncode) = self.fake.run_chroot(
-            '/bin/busybox --install -s /bin', self.target_dir, capture_output=True)
+            '/bin/busybox --install -s /bin', self.target_dir)
         assert stderr is not None
         assert not stderr.strip()
 
@@ -270,7 +270,7 @@ class TestFiles:
         self._prepare_chroot()
 
         (out, err, ret) = self.fake.run_cmd(
-            f'stat -c \'%u %g %a\'  {self.target_dir}/bin/busybox', capture_output=True)
+            f'stat -c \'%u %g %a\'  {self.target_dir}/bin/busybox')
         assert ret == 0
         assert err is not None
         assert not err.strip()
@@ -294,7 +294,7 @@ class TestFiles:
         assert files
 
         (out, err, ret) = self.fake.run_sudo(
-            f'file {self.target_dir}/root_chroot', capture_output=True)
+            f'file {self.target_dir}/root_chroot')
         assert ret == 0
         assert err is not None
         assert not err.strip()
@@ -303,7 +303,7 @@ class TestFiles:
 
         (out, err, ret) = self.fake.run_chroot(
             'stat -c \'%u %g %a\'  /root_chroot',
-            chroot=self.target_dir, capture_output=True)
+            chroot=self.target_dir)
         assert ret == 0
         assert err is not None
         assert not err.strip()
@@ -325,7 +325,7 @@ class TestFiles:
         assert os.path.isdir(f'{self.target_dir}/adir/subdir')
 
         (out, err, ret) = self.fake.run_cmd(
-            f'file {self.target_dir}/adir/subdir/a', capture_output=True)
+            f'file {self.target_dir}/adir/subdir/a')
         assert ret == 0
         assert err is not None
         assert not err.strip()
@@ -333,7 +333,7 @@ class TestFiles:
         assert 'ASCII text' in out
 
         (out, err, ret) = self.fake.run_cmd(
-            f'stat -c \'%u %g %a\'  {self.target_dir}/adir/subdir/a', capture_output=True)
+            f'stat -c \'%u %g %a\'  {self.target_dir}/adir/subdir/a')
         assert ret == 0
         assert err is not None
         assert not err.strip()
@@ -341,7 +341,7 @@ class TestFiles:
         assert '0 0 644' in out.strip()
 
         (out, err, ret) = self.fake.run_cmd(
-            f'file {self.target_dir}/adir/subdir/b', capture_output=True)
+            f'file {self.target_dir}/adir/subdir/b')
         assert ret == 0
         assert err is not None
         assert not err.strip()
@@ -349,7 +349,7 @@ class TestFiles:
         assert 'ASCII text' in out
 
         (out, err, ret) = self.fake.run_cmd(
-            f'stat -c \'%u %g %a\'  {self.target_dir}/adir/subdir/b', capture_output=True)
+            f'stat -c \'%u %g %a\'  {self.target_dir}/adir/subdir/b')
         assert ret == 0
         assert err is not None
         assert not err.strip()
@@ -373,7 +373,7 @@ class TestFiles:
         assert files
 
         (out, err, ret) = self.fake.run_fake(
-            f'file {self.target_dir}/cp_root_mode', capture_output=True)
+            f'file {self.target_dir}/cp_root_mode')
         assert ret == 0
         assert err is not None
         assert not err.strip()
@@ -381,7 +381,7 @@ class TestFiles:
         assert 'ASCII text' in out
 
         (out, err, ret) = self.fake.run_fake(
-            f'stat -c \'%u %g %a\'  {self.target_dir}/cp_root_mode', capture_output=True)
+            f'stat -c \'%u %g %a\'  {self.target_dir}/cp_root_mode')
         assert ret == 0
         assert err is not None
         assert not err.strip()
@@ -406,7 +406,7 @@ class TestFiles:
         assert files
 
         (out, err, ret) = self.fake.run_fake(
-            f'file {self.target_dir}/mv_root_move', capture_output=True)
+            f'file {self.target_dir}/mv_root_move')
         assert ret == 0
         assert err is not None
         assert not err.strip()
@@ -414,7 +414,7 @@ class TestFiles:
         assert 'ASCII text' in out
 
         (out, err, ret) = self.fake.run_fake(
-            f'stat -c \'%u %g %a\'  {self.target_dir}/mv_root_move', capture_output=True)
+            f'stat -c \'%u %g %a\'  {self.target_dir}/mv_root_move')
         assert ret == 0
         assert err is not None
         assert not err.strip()
@@ -439,7 +439,7 @@ class TestFiles:
         assert files
 
         (out, err, ret) = self.fake.run_fake(
-            f'file {self.target_dir}/target', capture_output=True)
+            f'file {self.target_dir}/target')
         assert ret == 0
         assert err is not None
         assert not err.strip()
@@ -447,7 +447,7 @@ class TestFiles:
         assert 'ASCII text' in out
 
         (out, err, ret) = self.fake.run_fake(
-            f'stat -c \'%u %g %a\'  {self.target_dir}/target', capture_output=True)
+            f'stat -c \'%u %g %a\'  {self.target_dir}/target')
         assert ret == 0
         assert err is not None
         assert not err.strip()
@@ -457,7 +457,7 @@ class TestFiles:
         assert '664' in out.strip() or '644' in out.strip()
 
         (out, err, ret) = self.fake.run_fake(
-            f'cat  {self.target_dir}/target', capture_output=True)
+            f'cat  {self.target_dir}/target')
         assert ret == 0
         assert err is not None
         assert not err.strip()
@@ -482,7 +482,7 @@ class TestFiles:
         assert files
 
         (out, err, ret) = self.fake.run_cmd(
-            f'file {self.target_dir}/owned', capture_output=True)
+            f'file {self.target_dir}/owned')
         assert ret == 0
         assert err is not None
         assert not err.strip()
@@ -490,7 +490,7 @@ class TestFiles:
         assert 'ASCII text' in out
 
         (out, err, ret) = self.fake.run_cmd(
-            f'stat -c \'%u %g %a\'  {self.target_dir}/owned', capture_output=True)
+            f'stat -c \'%u %g %a\'  {self.target_dir}/owned')
         assert ret == 0
         assert err is not None
         assert not err.strip()
@@ -499,7 +499,7 @@ class TestFiles:
         assert f'{os.getuid()} {os.getgid()}' in out.strip()
 
         (out, err, ret) = self.fake.run_cmd(
-            f'file {self.target_dir}/root_owner', capture_output=True)
+            f'file {self.target_dir}/root_owner')
         assert ret == 0
         assert err is not None
         assert not err.strip()
@@ -507,7 +507,7 @@ class TestFiles:
         assert 'ASCII text' in out
 
         (out, err, ret) = self.fake.run_cmd(
-            f'stat -c \'%u %g %a\'  {self.target_dir}/root_owner', capture_output=True)
+            f'stat -c \'%u %g %a\'  {self.target_dir}/root_owner')
         assert ret == 0
         assert err is not None
         assert not err.strip()
@@ -526,8 +526,7 @@ class TestFiles:
             script,
             params=f'{self.target_dir} 1234',
             environment=EnvironmentType.SHELL,
-            cwd=self.target_dir,
-            capture_output=True
+            cwd=self.target_dir
         )
         assert res
         (out, err, ret) = res
@@ -548,8 +547,7 @@ class TestFiles:
             script,
             params=f'{self.target_dir} 1234',
             environment=EnvironmentType.SUDO,
-            cwd=self.target_dir,
-            capture_output=True
+            cwd=self.target_dir
         )
         assert res
         (out, err, ret) = res
@@ -570,8 +568,7 @@ class TestFiles:
             script,
             params=f'{self.target_dir} 1234',
             environment=EnvironmentType.FAKEROOT,
-            cwd=self.target_dir,
-            capture_output=True
+            cwd=self.target_dir
         )
         assert res
         (out, err, ret) = res
@@ -592,8 +589,7 @@ class TestFiles:
             script,
             params='/ 1234',
             environment=EnvironmentType.CHROOT,
-            cwd=self.target_dir,
-            capture_output=True
+            cwd=self.target_dir
         )
         assert res
         (out, err, ret) = res
@@ -612,7 +608,7 @@ class TestFiles:
         self.files.extract_tarball(tar, tempdir, True)
 
         (out, err, ret) = self.fake.run_cmd(
-            f'stat -c \'%u %g %a\'  {tempdir}/bin/busybox', capture_output=True)
+            f'stat -c \'%u %g %a\'  {tempdir}/bin/busybox')
         assert ret == 0
         assert err is not None
         assert not err.strip()
@@ -623,7 +619,7 @@ class TestFiles:
         self.files.extract_tarball(tar, tempdir, True)
 
         (out, err, ret) = self.fake.run_cmd(
-            f'stat -c \'%u %g %a\'  {tempdir}/bin/busybox', capture_output=True)
+            f'stat -c \'%u %g %a\'  {tempdir}/bin/busybox')
         assert ret == 0
         assert err is not None
         assert not err.strip()
@@ -645,7 +641,7 @@ class TestFiles:
             use_sudo=False)
 
         (out, err, ret) = self.fake.run_fake(
-            f'stat -c \'%u %g %a\'  {temp}/bin/busybox', capture_output=True)
+            f'stat -c \'%u %g %a\'  {temp}/bin/busybox')
         assert ret == 0
         assert err is not None
         assert not err.strip()
@@ -653,7 +649,7 @@ class TestFiles:
         assert '0 0 755' in out.strip()
 
         (out, err, ret) = self.fake.run_cmd(
-            f'stat -c \'%u %g %a\'  {temp}/bin/busybox', capture_output=True)
+            f'stat -c \'%u %g %a\'  {temp}/bin/busybox')
         assert ret == 0
         assert err is not None
         assert not err.strip()
@@ -667,7 +663,7 @@ class TestFiles:
             use_sudo=False)
 
         (out, err, ret) = self.fake.run_fake(
-            f'stat -c \'%u %g %a\'  {temp}/bin/busybox', capture_output=True)
+            f'stat -c \'%u %g %a\'  {temp}/bin/busybox')
         assert ret == 0
         assert err is not None
         assert not err.strip()
@@ -694,7 +690,7 @@ class TestFiles:
         )
 
         (out, err, ret) = self.fake.run_cmd(
-            f'stat -c \'%u %g %a\'  {outdir}/myroot.tar', capture_output=True)
+            f'stat -c \'%u %g %a\'  {outdir}/myroot.tar')
         assert ret == 0
         assert err is not None
         assert not err.strip()
@@ -702,7 +698,7 @@ class TestFiles:
         assert f'{os.getuid()} {os.getgid()} 644' in out.strip()
 
         (out, err, ret) = self.fake.run_cmd(
-            f'tar --list --verbose --file={outdir}/myroot.tar | grep ./bin/busybox', capture_output=True)
+            f'tar --list --verbose --file={outdir}/myroot.tar | grep ./bin/busybox')
         assert ret == 0
         assert err is not None
         assert not err.strip()
@@ -718,7 +714,7 @@ class TestFiles:
         )
 
         (out, err, ret) = self.fake.run_cmd(
-            f'stat -c \'%u %g %a\'  {outdir}/myroot.tar', capture_output=True)
+            f'stat -c \'%u %g %a\'  {outdir}/myroot.tar')
         assert ret == 0
         assert err is not None
         assert not err.strip()

--- a/tests/test_initrd.py
+++ b/tests/test_initrd.py
@@ -206,7 +206,7 @@ class TestInitrd:
             self.generator.target_dir)
 
         (out, err, _returncode) = self.fake.run_sudo(
-            f'stat -c \'%a\' {self.generator.target_dir}/root/dummy.txt', capture_output=True)
+            f'stat -c \'%a\' {self.generator.target_dir}/root/dummy.txt')
         assert out is not None
         out = out.split('\n')[-2]
         mode = oct(
@@ -216,7 +216,7 @@ class TestInitrd:
         assert not err.strip()
 
         (out, err, _returncode) = self.fake.run_sudo(
-            f'stat -c \'%u %g\' {self.generator.target_dir}/root/dummy.txt', capture_output=True)
+            f'stat -c \'%u %g\' {self.generator.target_dir}/root/dummy.txt')
         assert out is not None
         out = out.split('\n')[-2]
         assert out.strip() == '0 0'
@@ -224,13 +224,13 @@ class TestInitrd:
         assert not err.strip()
 
         (out, err, _returncode) = self.fake.run_sudo(
-            f'stat -c \'%a\' {self.generator.target_dir}/root/other.txt', capture_output=True)
+            f'stat -c \'%a\' {self.generator.target_dir}/root/other.txt')
         assert out is not None
         out = out.split('\n')[-2]
         assert out.strip() == '700'
 
         (out, err, _returncode) = self.fake.run_sudo(
-            f'stat -c \'%u %g\' {self.generator.target_dir}/root/other.txt', capture_output=True)
+            f'stat -c \'%u %g\' {self.generator.target_dir}/root/other.txt')
         assert out is not None
         out = out.split('\n')[-2]
         assert out.strip() == '123 456'


### PR DESCRIPTION
# Changes

**Please see this as an RFC, not something I absolutely have to push into the code.**


This implements two major changes:

1. drop of caputre_output paramter of fake.run_cmd:

>     The main goal here is to not have output written directly to stdout and stderr.
>     
>     The capture_output parameter does not make a lot of sense.
>     With capture_output=False the output was written directly to stdout and
>     with capture_output=True the output was captured and written to the log
>     and returned from the function.
>     
>     Now the output (stdout and stderr) is always caputred and returned and
>     written to the log. I.e. it is not written to stdout anymore.
>     
>     When an out stream is passed (stdout parameter != None), the output
>     is not written to the log because it could be binary (i.e. it is used for cpio output).
>     This is no change from the previous implementation.
>     
>     Additionally, stdin is set to subprocess.DEVNULL. This prevents processes
>     executed from changing the terminal settings (i.e. changing the behavior of
>     \n to just cause newline instead of a new line and carriage return).
>     Changing the terminal settings can mess up the output during parallel builds.

2.  Allow sending the log output directly to a file

>     This allows redirecting the output of the tool to a logfile, without
>     relying on an external process (e.g. bash) to do the redirection.
>    
>     This also moves exception and banner printing to the log.
>    
>     It is required to enable clean parallel builds.


# Tests results
```bash
==============================================================================
Robot Tests                                                                   
==============================================================================
Robot Tests.Boot                                                              
==============================================================================
Kernel exists                                                         | PASS |
------------------------------------------------------------------------------
Config is OK                                                          | PASS |
------------------------------------------------------------------------------
Script was executed                                                   | PASS |
------------------------------------------------------------------------------
Robot Tests.Boot                                                      | PASS |
3 tests, 3 passed, 0 failed
==============================================================================
Robot Tests.Initrd                                                            
==============================================================================
Root Device is Mounted                                                | PASS |
------------------------------------------------------------------------------
Devices are Created                                                   | PASS |
------------------------------------------------------------------------------
Rootfs should be set up                                               | PASS |
------------------------------------------------------------------------------
File dummy.txt should be OK                                           | PASS |
------------------------------------------------------------------------------
File other.txt should be OK                                           | PASS |
------------------------------------------------------------------------------
Modules are installed                                                 | PASS |
------------------------------------------------------------------------------
Check modules loaded by init                                          | PASS |
------------------------------------------------------------------------------
Robot Tests.Initrd                                                    | PASS |
7 tests, 7 passed, 0 failed
==============================================================================
Robot Tests.Root                                                              
==============================================================================
Systemd should exist                                                  | PASS |
------------------------------------------------------------------------------
Fakeoot config executed                                               | PASS |
------------------------------------------------------------------------------
Fakechroot config was executed                                        | PASS |
------------------------------------------------------------------------------
Chroot config was executed                                            | PASS |
------------------------------------------------------------------------------
Resolv.conf symlink should exist                                      | PASS |
------------------------------------------------------------------------------
Robot Tests.Root                                                      | PASS |
5 tests, 5 passed, 0 failed
==============================================================================
Robot Tests                                                           | PASS |
15 tests, 15 passed, 0 failed
==============================================================================
```
# Developer Checklist:
- [ ] Test: Changes are tested
- [ ] Doc: Documentation has been updated 
- [ ] Git: Informative git commit message(s)

# Reviewer checklist:
- [ ] Review: Changes are reviewed
- [ ] Review: Tested by the reviewer

