### PR TITLE
Add symlinks needed for amd64 and dynamic linked binaries

### DIFF
--- a/ebcl/tools/initrd/initrd.py
+++ b/ebcl/tools/initrd/initrd.py
@@ -323,6 +323,9 @@ class InitrdGenerator:
 
         # Create lib and bin folder symlinks
         self.config.fake.run_sudo(f'ln -sf usr/lib {self.target_dir}/lib')
+        self.config.fake.run_sudo(f'ln -sf usr/lib32 {self.target_dir}/lib32')
+        self.config.fake.run_sudo(f'ln -sf usr/lib64 {self.target_dir}/lib64')
+        self.config.fake.run_sudo(f'ln -sf usr/libx32 {self.target_dir}/libx32')
         self.config.fake.run_sudo(f'ln -sf usr/bin {self.target_dir}/bin')
         self.config.fake.run_sudo(f'ln -sf usr/sbin {self.target_dir}/sbin')
 


### PR DESCRIPTION
# Changes

- Add symlinks for lib64, lib32 and libx32.

Required for using dynamic linked binaries in the initrd of AMD64 images, e.g. busybox.
Mandatory change for Ubuntu Noble based images.

# Dependencies:

# Tests results
```bash

```


# Developer Checklist:

- [ ] Test: Changes are tested
- N/A Doc: Documentation has been updated 
- [x] Git: Informative git commit message(s)
- N/A Issue: If a related GitHub issue exists, linking is done

# Reviewer checklist:
- [ ] Review: Changes are reviewed
- [ ] Review: Tested by the reviewer

