### PR TITLE
Apt options for elosd

### DIFF
--- a/ebcl/tools/root/debootstrap.py
+++ b/ebcl/tools/root/debootstrap.py
@@ -28,6 +28,7 @@ class DebootstrapRootGenerator:
         self.cache_folder = get_cache_folder('debootstrap')
         self.debootstrap_variant = debootstrap_variant
         self.apt_env = 'DEBIAN_FRONTEND=noninteractive TZ=Etc/UTC'
+        self.apt_options = ' -o DPkg::Options::=--force-confold --allow-downgrades '
 
     def _get_apt_hash(self, debootstrap_hash: str) -> str:
         """ Generate a hash for the apt configuration """
@@ -328,7 +329,7 @@ class DebootstrapRootGenerator:
             if not self.config.install_recommends:
                 no_recommends = "--no-install-recommends "
             fake.run_chroot(
-                f'bash -c "{self.apt_env} apt install -y {no_recommends}{packages} --allow-downgrades"',
+                f'bash -c "{self.apt_env} apt install -y {self.apt_options}  {no_recommends}{packages}"',
                 chroot=self.config.target_dir,
                 check=True
             )

--- a/robot_tests/data/config/elosd.json
+++ b/robot_tests/data/config/elosd.json
@@ -1,0 +1,107 @@
+{
+    "root": {
+        "elos": {
+            "UseEnv": false,
+            "LogFilter": "",
+            "LogLevel": "ERROR",
+            "ClientInputs": {
+                "Plugins": {
+                    "LocalTcpClient": {
+                        "File": "client_tcp.so",
+                        "Run": "always",
+                        "Config": {
+                            "ConnectionLimit": 200,
+                            "Port": 54321,
+                            "Interface": "127.0.0.1",
+                            "EventBlacklist": ".event.messageCode 1000 LE",
+                            "authorizedProcesses": [
+                                ".process.uid 0 EQ .process.gid 0 EQ AND .process.exec '/usr/bin/elosc' STRCMP AND",
+                                ".process.gid 200 EQ .process.exec '/usr/bin/elosc' STRCMP AND",
+                                ".process.pid 1 EQ"
+                            ]
+                        }
+                    },
+                    "PublicTcpClient": {
+                        "File": "client_tcp.so",
+                        "Run": "always",
+                        "Config": {
+                            "Port": 54322,
+                            "Interface": "0.0.0.0",
+                            "EventBlacklist": "1 1 EQ",
+                            "authorizedProcesses": []
+                        }
+                    }
+                }
+            },
+            "EventLogging": {
+                "Plugins": {
+                    "fetchapi": {
+                        "File": "backend_fetchapi.so",
+                        "Run": "always",
+                        "Filter": [
+                            "1 1 EQ"
+                        ],
+                        "Config": {
+                            "BufferSize": 100
+                        }
+                    },
+                    "JsonBackend": {
+                        "File": "backend_json.so",
+                        "Run": "always",
+                        "Filter": [
+                            "1 1 EQ"
+                        ],
+                        "Config": {
+                            "StoragePath": "/var/log/elosd_%host%_%date%_%count%.log",
+                            "MaxSize": 60000,
+                            "Flags": [
+                                "O_SYNC"
+                            ]
+                        }
+                    },
+                    "DLT": {
+                        "File": "backend_dlt_logger.so",
+                        "Run": "never",
+                        "Filter": [
+                            ".e.messageCode 1000 GE"
+                        ],
+                        "Config": {
+                            "Connection": "/tmp/dlt",
+                            "EcuId": "ECU1",
+                            "AppId": "ELOS"
+                        }
+                    }
+                }
+            },
+            "Scanner": {
+                "Plugins": {
+                    "OomKiller": {
+                        "File": "scanner_oomkiller.so",
+                        "Run": "always"
+                    },
+                    "SyslogScanner": {
+                        "File": "scanner_syslog.so",
+                        "Run": "always",
+                        "Config": {
+                            "SyslogPath": "/dev/log",
+                            "MappingRules": {
+                                "MessageCodes": {
+                                    "8004": ".event.source.appName 'sshd' STRCMP .e.payload r'authentication failure' REGEX AND",
+                                    "8005": ".event.source.appName 'sshd' STRCMP .e.payload r'Accepted password for' REGEX AND",
+                                    "1001": "1 1 EQ"
+                                }
+                            }
+                        }
+                    },
+                    "KmsgScanner": {
+                        "File": "scanner_kmsg.so",
+                        "Run": "always",
+                        "Config": {
+                            "KmsgFile": "/dev/kmsg"
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/robot_tests/data/root.yaml
+++ b/robot_tests/data/root.yaml
@@ -5,6 +5,9 @@ packages:
   - systemd
   - udev        # udev will create the device node for ttyS0
   - util-linux
+  - elos
+host_files:
+  - source: config/*
 scripts:
   - name: root_config_sudo.sh
     env: sudo


### PR DESCRIPTION
# Changes

Build stucks with:

```bash
Configuration file '/etc/elos/elosd.json'
 ==> File on system created by you or by a script.
 ==> File also in package provided by package maintainer.
   What would you like to do about it ?  Your options are:
    Y or I  : install the package maintainer's version
    N or O  : keep your currently-installed version
      D     : show the differences between the versions
      Z     : start a shell to examine the situation
 The default action is to keep your current version.
*** elosd.json (Y/I/N/O/D/Z) [default=N] ? 
```

if config is already available when elosd is installed. To fix this the option `-o DPkg::Options::=--force-confold` needs to be added to the `apt install` command.

Revealed by fixing copying apt config with release 1.3.14.

# Dependencies:

None.

# Tests results
```bash
<!-- add Robot test CLI logs here. -->
```

# Developer Checklist:

- [ ] Test: Changes are tested
- N/A Doc: Documentation has been updated 
- [ ] Git: Informative git commit message(s)
- [ ] Issue: If a related GitHub issue exists, linking is done

# Reviewer checklist:
- [ ] Review: Changes are reviewed
- [ ] Review: Tested by the reviewer
