### PR TITLE
Use primary distro in ebcl_primary_repo to remove hardcoded choice of jammy.

### DIFF
--- a/ebcl/common/apt.py
+++ b/ebcl/common/apt.py
@@ -414,9 +414,9 @@ class Apt:
         return cls.ebcl(arch, "ebcl", release, ['prod', 'dev'])
 
     @classmethod
-    def ebcl_primary_repo(cls, arch: CpuArch, release: str = '1.5') -> Self:
+    def ebcl_primary_repo(cls, arch: CpuArch, primary_distro, release: str = '1.5') -> Self:
         """Get the EBcL apt repo for upstream jammy components."""
-        return cls.ebcl(arch, "jammy", release, ['main'])
+        return cls.ebcl(arch, primary_distro if primary_distro else "jammy", release, ['main'])
 
     def __init__(
         self,

--- a/ebcl/common/config.py
+++ b/ebcl/common/config.py
@@ -182,7 +182,6 @@ class Config:
         """ Load yaml configuration. """
         self._parse_yaml(self.config_file)
         if self.use_ebcl_apt:
-            print('Adding EBcL apt repo')
             ebcl_apt = Apt.ebcl_apt(self.arch)
             self.proxy.add_apt(ebcl_apt)
             self.apt_repos.append(ebcl_apt)

--- a/ebcl/common/config.py
+++ b/ebcl/common/config.py
@@ -181,6 +181,14 @@ class Config:
     def parse(self) -> None:
         """ Load yaml configuration. """
         self._parse_yaml(self.config_file)
+        if self.use_ebcl_apt:
+            print('Adding EBcL apt repo')
+            ebcl_apt = Apt.ebcl_apt(self.arch)
+            self.proxy.add_apt(ebcl_apt)
+            self.apt_repos.append(ebcl_apt)
+            ebcl_main = Apt.ebcl_primary_repo(self.arch, self.primary_distro)
+            self.proxy.add_apt(ebcl_main)
+            self.apt_repos.append(ebcl_main)
 
     def _parse_yaml(self, file: str) -> None:
         """ Load yaml configuration. """
@@ -191,7 +199,7 @@ class Config:
 
         base = config.get('base', None)
         if base:
-            # Hanlde parent config files
+            # Handle parent config files
             if isinstance(base, str):
                 bases = [base]
             else:
@@ -236,13 +244,6 @@ class Config:
 
         if 'use_ebcl_apt' in config:
             self.use_ebcl_apt = config.get('use_ebcl_apt', False)
-            if self.use_ebcl_apt:
-                ebcl_apt = Apt.ebcl_apt(self.arch)
-                self.proxy.add_apt(ebcl_apt)
-                self.apt_repos.append(ebcl_apt)
-                ebcl_main = Apt.ebcl_primary_repo(self.arch, self.primary_distro)
-                self.proxy.add_apt(ebcl_main)
-                self.apt_repos.append(ebcl_main)
 
         host_files = parse_files(
             config.get('host_files', None),

--- a/ebcl/common/config.py
+++ b/ebcl/common/config.py
@@ -231,13 +231,16 @@ class Config:
 
             self.apt_repos += apt_repos
 
+        if 'primary_distro' in config:
+            self.primary_distro = config.get('primary_distro', None)
+
         if 'use_ebcl_apt' in config:
             self.use_ebcl_apt = config.get('use_ebcl_apt', False)
             if self.use_ebcl_apt:
                 ebcl_apt = Apt.ebcl_apt(self.arch)
                 self.proxy.add_apt(ebcl_apt)
                 self.apt_repos.append(ebcl_apt)
-                ebcl_main = Apt.ebcl_primary_repo(self.arch)
+                ebcl_main = Apt.ebcl_primary_repo(self.arch, self.primary_distro)
                 self.proxy.add_apt(ebcl_main)
                 self.apt_repos.append(ebcl_main)
 
@@ -424,9 +427,6 @@ class Config:
 
         if 'type' in config:
             self.type = BuildType.from_str(config.get('type', None))
-
-        if 'primary_distro' in config:
-            self.primary_distro = config.get('primary_distro', None)
 
         if 'debootstrap_flags' in config:
             self.debootstrap_flags = config.get('debootstrap_flags', None)

--- a/tests/data/root_distro.yaml
+++ b/tests/data/root_distro.yaml
@@ -1,0 +1,2 @@
+base: root.yaml
+primary_distro: noble

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -36,7 +36,7 @@ class TestConfig:
 
         config = Config(yaml_file, self.temp_dir)
 
-        assert len(config.apt_repos) == 2
+        assert len(config.apt_repos) == 4
         assert isinstance(config.apt_repos[0].repo, AptDebRepo)
         assert config.apt_repos[0].repo.dist == 'jammy'
         assert isinstance(config.apt_repos[1].repo, AptDebRepo)
@@ -64,7 +64,7 @@ class TestConfig:
 
         config = Config(yaml_file, self.temp_dir)
 
-        assert len(config.apt_repos) == 2
+        assert len(config.apt_repos) == 4
         assert isinstance(config.apt_repos[0].repo, AptDebRepo)
         assert config.apt_repos[0].repo.dist == 'jammy'
         assert isinstance(config.apt_repos[1].repo, AptDebRepo)
@@ -102,7 +102,7 @@ class TestConfig:
 
         config = Config(yaml_file, self.temp_dir)
 
-        assert len(config.apt_repos) == 2
+        assert len(config.apt_repos) == 4
         assert isinstance(config.apt_repos[0].repo, AptDebRepo)
         assert config.apt_repos[0].repo.dist == 'jammy'
         assert isinstance(config.apt_repos[1].repo, AptFlatRepo)
@@ -190,3 +190,14 @@ class TestConfig:
 
         del config
         assert not netrc_path.exists()
+
+    def test_distro_ebcl_apt_yaml(self):
+        """ Try to parse boot.yaml. """
+        yaml_file = os.path.join(
+            os.path.dirname(__file__), 'data', 'root_distro.yaml')
+
+        config = Config(yaml_file, self.temp_dir)
+
+        print(config.apt_repos)
+        print(config.primary_distro)
+

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -200,4 +200,3 @@ class TestConfig:
 
         print(config.apt_repos)
         print(config.primary_distro)
-


### PR DESCRIPTION
Use `primary_distro` for the repo choice as otherwise combinations of `use_ebcl_apt`
and `primary_distro != jammy` would fail with inconsistent repos.


# Developer Checklist:
- [ ] Test: Changes are tested
- [ ] Doc: Documentation has been updated 
- [ ] Git: Informative git commit message(s)
- [ ] Issue: If a related GitHub issue exists, linking is done

## Checklists for documentation
- [ ] Grammar: the content is grammatically correct
      (spelling, grammar, formatting, US English is used)
- [ ] Comprehensibility/Unambiguousness: the content is easy readable, clear to understand
- [ ] Correctness and consistency: the content is technically correct and consistent,
      no contradictions, no double descriptions
- [ ] Terminology: technical terms are clear and they are used correctly and documented in the glossary
- [ ] Level of detail: the content matches the detail level necessary for the reviewed object

# Reviewer checklist:
- [ ] Review: Changes are reviewed
- [ ] Review: Tested by the reviewer

## Checklists for documentation
- [ ] Grammar: the content is grammatically correct
      (spelling, grammar, formatting, US English is used)
- [ ] Comprehensibility/Unambiguousness: the content is easy readable, clear to understand
- [ ] Correctness and consistency: the content is technically correct and consistent,
      no contradictions, no double descriptions
- [ ] Terminology: technical terms are clear and they are used correctly and documented in the glossary
- [ ] Level of detail: the content matches the detail level necessary for the reviewed object
